### PR TITLE
Landing copy update + Lernunterlagen disclaimer

### DIFF
--- a/src/app/kurse/[kursId]/page.tsx
+++ b/src/app/kurse/[kursId]/page.tsx
@@ -29,6 +29,9 @@ export default async function KursPage({ params }: { params: Promise<{ kursId: s
             {kurs.description && (
               <p className="mt-3 max-w-2xl text-base leading-relaxed text-gray-600">{kurs.description}</p>
             )}
+            <p className="mt-3 max-w-2xl text-xs text-gray-400">
+              Alle Lernunterlagen ohne Gewähr auf Richtigkeit und Vollständigkeit. Fehler können nicht ausgeschlossen werden.
+            </p>
           </div>
           <ShareButton title={kurs.title} />
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ export default function HomePage() {
             </span>
           </span>
           <br />
-          <span>Pass faster.</span>
+          <span>Learn Faster.</span>
         </h1>
 
         <div className="mt-7 flex justify-center">
@@ -68,8 +68,8 @@ export default function HomePage() {
           />
           <CaseCard
             number="02"
-            title="Step-by-step solutions"
-            body="Understand the calculation logic, not just the final number."
+            title="Calculation frameworks"
+            body="Understand methods, formulas, and reasoning clearly."
             imagePosition="center center"
             className="hidden md:flex relative z-10 md:min-h-[350px]"
           />

--- a/src/components/kurse/UnitPaywall.tsx
+++ b/src/components/kurse/UnitPaywall.tsx
@@ -40,6 +40,10 @@ export default function UnitPaywall({ unitId, title, description, canceled }: Pr
       <p className="mt-3 text-center text-[11px] text-gray-400">
         Sichere Bezahlung über Stripe. Einmalige Zahlung — dauerhafter Zugriff.
       </p>
+
+      <p className="mt-2 text-center text-[11px] text-gray-400">
+        Alle Lernunterlagen ohne Gewähr auf Richtigkeit und Vollständigkeit. Fehler können nicht ausgeschlossen werden.
+      </p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Landing page: change second-line heading from "Pass faster." to "Learn Faster." and replace card 02 ("Step-by-step solutions") with "Calculation frameworks" / "Understand methods, formulas, and reasoning clearly."
- Add a German "ohne Gewähr" disclaimer to the Kurs detail page and the UnitPaywall: *"Alle Lernunterlagen ohne Gewähr auf Richtigkeit und Vollständigkeit. Fehler können nicht ausgeschlossen werden."*

## Test plan
- [ ] Visit `/` and confirm the new heading and updated card 02 render correctly on desktop and mobile.
- [ ] Visit a Kurs page (`/kurse/[kursId]`) and confirm the disclaimer appears under the course description.
- [ ] Visit a locked Unit and confirm the disclaimer appears at the bottom of the UnitPaywall, below the Stripe note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)