### PR TITLE
feat: add AGB page

### DIFF
--- a/src/app/agb/page.tsx
+++ b/src/app/agb/page.tsx
@@ -1,0 +1,118 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'AGB – Dokum',
+}
+
+export default function AgbPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-12">
+      <Link href="/" className="mb-8 inline-block text-sm text-gray-500 transition-colors hover:text-gray-900">
+        ← Zurück
+      </Link>
+
+      <h1 className="mb-8 text-3xl font-bold text-gray-900">Allgemeine Geschäftsbedingungen</h1>
+
+      <div className="prose prose-sm max-w-none text-gray-600">
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ÜBERSICHT</h2>
+        <p>Diese Website wird von Dokum betrieben. Überall auf der Webseite beziehen sich die Begriffe &quot;wir&quot;, &quot;uns&quot; und &quot;unsere/e&quot; auf Dokum. Dokum bietet diese Website, einschließlich aller Informationen, Tools und Dienste, die auf dieser Website verfügbar sind, Ihnen, dem Benutzer, unter der Bedingung an, dass Sie alle hier angegebenen Bedingungen, Konditionen, Richtlinien und Hinweise akzeptieren.</p>
+        <p>Wenn Sie unsere Website besuchen und/oder unsere Online-Lernhilfen und Prüfungsvorbereitungen nutzen, nutzen Sie unseren &quot;Dienst&quot; und erklären sich damit einverstanden, an die folgenden Allgemeinen Geschäftsbedingungen (&quot;Allgemeine Geschäftsbedingungen&quot;, &quot;Bedingungen&quot;) gebunden zu sein, einschließlich der zusätzlichen Geschäftsbedingungen und Richtlinien, die hierin erwähnt werden und/oder per Hyperlink verfügbar sind. Diese Allgemeinen Geschäftsbedingungen gelten für alle Benutzer der Website.</p>
+        <p>Bitte lesen Sie diese Allgemeinen Geschäftsbedingungen sorgfältig durch, bevor Sie auf unsere Website zugreifen oder diese benutzen. Durch den Zugriff auf oder die Nutzung eines jeglichen Teils der Website erklären Sie sich mit diesen Allgemeinen Geschäftsbedingungen einverstanden. Sind Sie nicht mit allen Geschäftsbedingungen dieser Vereinbarung einverstanden, dürfen Sie nicht auf die Website zugreifen oder irgendwelche Dienste nutzen.</p>
+        <p>Alle neuen Funktionen oder Tools, die zum aktuellen Dienst hinzugefügt werden, unterliegen ebenfalls den Allgemeinen Geschäftsbedingungen. Sie können die aktuellste Version der Allgemeinen Geschäftsbedingungen jederzeit auf dieser Seite einsehen. Wir behalten uns das Recht vor, Teile dieser Allgemeinen Geschäftsbedingungen durch Veröffentlichung von Updates und/oder Änderungen unserer Website zu aktualisieren, zu ändern oder zu ersetzen. Es liegt in Ihrer Verantwortung, diese Seite regelmäßig auf mögliche Änderungen zu überprüfen.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 1 - NUTZUNGSBEDINGUNGEN</h2>
+        <p>Mit der Zustimmung zu diesen Allgemeinen Geschäftsbedingungen erklären Sie, dass Sie in dem Land Ihres Wohnsitzes mindestens volljährig sind oder dass Sie in dem Land Ihres Wohnsitz volljährig sind und uns Ihre Zustimmung gegeben haben, dass Ihre minderjährigen Angehörigen diese Website nutzen dürfen.</p>
+        <p>Sie dürfen unsere Dienstleistungen weder für illegale oder nicht autorisierte Zwecke nutzen noch dürfen Sie durch die Nutzung der Serviceleistung gegen Gesetze in Ihrer Gerichtsbarkeit verstoßen (einschließlich, aber nicht beschränkt auf Urheberrechtsgesetze).</p>
+        <p>Sie dürfen keine Würmer oder Viren oder sonstigen Code destruktiver Art übertragen.</p>
+        <p>Der Verstoß gegen oder die Verletzung irgendeiner dieser Bedingungen führt zur sofortigen Kündigung Ihrer Serviceleistungen.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 2 - ALLGEMEINE BEDINGUNGEN</h2>
+        <p>Wir behalten uns das Recht vor, einer Person die Serviceleistung jederzeit aus beliebigem Grund zu verweigern.</p>
+        <p>Sie nehmen zur Kenntnis, dass Ihre Informationen unverschlüsselt übertragen werden können und (a) Übertragungen über verschiedene Netzwerke sowie (b) Änderungen beinhalten können, um den technischen Anforderungen von verbundenen Netzwerken oder Geräten zu entsprechen und sich an diese anzupassen.</p>
+        <p>Sie verpflichten sich, ohne ausdrückliche schriftliche Genehmigung von uns keinen Teil der Serviceleistung, die Nutzung der Serviceleistung oder den Zugriff auf die Serviceleistung zu reproduzieren, zu vervielfältigen, zu kopieren, zu verkaufen, weiterzuverkaufen oder zu verwerten.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 3 - GENAUIGKEIT, VOLLSTÄNDIGKEIT UND RECHTZEITIGKEIT DER INFORMATIONEN</h2>
+        <p>Wir sind nicht verantwortlich, wenn die auf dieser Seite zur Verfügung gestellten Informationen nicht genau, vollständig oder aktuell sind. Das Material auf dieser Website dient der allgemeinen Information und sollte nicht als alleinige Grundlage für Entscheidungen herangezogen werden. Jegliches Vertrauen in das Material auf dieser Website geschieht auf eigene Verantwortung.</p>
+        <p>Wir behalten uns das Recht vor, Inhalte auf dieser Website jederzeit zu ändern, sind aber nicht verpflichtet, irgendwelche Informationen auf unserer Website zu aktualisieren.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 4 - ÄNDERUNGEN AN DER LEISTUNG UND DEN PREISEN</h2>
+        <p>Die Preise für unsere Dienstleistungen können ohne vorherige Ankündigung geändert werden.</p>
+        <p>Wir behalten uns das Recht vor, die Serviceleistung (oder einen jeglichen Teil oder Inhalt davon) ohne Ankündigung jederzeit zu ändern oder zu beenden.</p>
+        <p>Wir sind weder Ihnen noch Dritten gegenüber haftbar für Änderungen, Preisänderungen, Sperrung oder Einstellung der Serviceleistung.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 5 - DIENSTLEISTUNGEN</h2>
+        <p>Unsere Lernhilfen und Prüfungsvorbereitungen sind ausschließlich online über die Website verfügbar. Nach erfolgreicher Zahlung erhalten Sie sofortigen Zugriff auf die digitalen Inhalte und Lernmaterialien.</p>
+        <p>Wir behalten uns das Recht vor, den Zugang zu unseren Dienstleistungen auf gewisse Personen, geografische Regionen oder Gerichtsbarkeiten zu beschränken. Alle Beschreibungen oder Preise können jederzeit ohne Vorankündigung und nach unserem alleinigen Ermessen geändert werden.</p>
+        <p>Wir garantieren nicht, dass die Qualität von Dienstleistungen, Informationen oder anderen Materialien, die von Ihnen erworben wurden, Ihren Erwartungen entspricht.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 6 - WIDERRUFSRECHT BEI DIGITALEN INHALTEN</h2>
+        <h3 className="mt-6 mb-2 text-base font-semibold text-gray-900">Widerrufsbelehrung</h3>
+        <p>Sie haben das Recht, binnen vierzehn Tagen ohne Angabe von Gründen diesen Vertrag zu widerrufen.</p>
+        <p>Die Widerrufsfrist beträgt vierzehn Tage ab dem Tag des Vertragsabschlusses.</p>
+        <p>Um Ihr Widerrufsrecht auszuüben, müssen Sie uns mittels einer eindeutigen Erklärung (z.B. ein mit der Post versandter Brief oder eine E-Mail) über Ihren Entschluss, diesen Vertrag zu widerrufen, informieren.</p>
+        <p>Zur Wahrung der Widerrufsfrist reicht es aus, dass Sie die Mitteilung über die Ausübung des Widerrufsrechts vor Ablauf der Widerrufsfrist absenden.</p>
+        <h3 className="mt-6 mb-2 text-base font-semibold text-gray-900">Folgen des Widerrufs</h3>
+        <p>Wenn Sie diesen Vertrag widerrufen, haben wir Ihnen alle Zahlungen, die wir von Ihnen erhalten haben, unverzüglich und spätestens binnen vierzehn Tagen ab dem Tag zurückzuzahlen, an dem die Mitteilung über Ihren Widerruf dieses Vertrags bei uns eingegangen ist.</p>
+        <h3 className="mt-6 mb-2 text-base font-semibold text-gray-900">Besonderheit bei digitalen Inhalten</h3>
+        <p>Da Sie nach erfolgreicher Zahlung sofortigen Zugriff auf die digitalen Lernmaterialien und Inhalte erhalten, beginnt die Leistungserbringung unmittelbar nach Vertragsschluss. Bitte beachten Sie, dass Ihr Widerrufsrecht vorzeitig erlischt, sobald Sie mit dem Herunterladen oder dem Streaming der digitalen Inhalte begonnen haben.</p>
+        <p>Haben Sie die digitalen Inhalte noch nicht abgerufen oder heruntergeladen, steht Ihnen das volle 14-tägige Widerrufsrecht zu.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 7 - RICHTIGKEIT DER RECHNUNGS- UND KONTOINFORMATIONEN</h2>
+        <p>Wir behalten uns das Recht vor, jegliche Bestellung, die Sie bei uns aufgeben, abzulehnen. Falls wir eine Bestellung ändern oder stornieren, werden wir versuchen, Sie zu benachrichtigen, indem wir die E-Mail-Adresse kontaktieren, die zum Zeitpunkt der Bestellung angegeben wurde.</p>
+        <p>Sie stimmen zu, aktuelle, vollständige und richtige Kauf- und Kontoinformationen für alle Käufe anzugeben. Sie stimmen zu, Ihr Konto und andere Informationen, einschließlich Ihrer E-Mail-Adresse, umgehend zu aktualisieren, damit wir Ihre Transaktionen abschließen und Sie bei Bedarf kontaktieren können.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 8 - ZUSÄTZLICHE TOOLS</h2>
+        <p>Wir bieten Ihnen möglicherweise Zugriff auf Tools von Drittanbietern, die wir weder überwachen noch kontrollieren oder beeinflussen können. Sie stimmen zu, dass wir den Zugriff auf diese Tools &quot;wie besehen&quot; und &quot;wie verfügbar&quot; ohne jegliche Garantien zur Verfügung stellen. Wir übernehmen keinerlei Haftung, die sich aus Ihrer Nutzung von zusätzlichen Drittanbieter-Tools ergibt.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 9 - DRITTANBIETER-LINKS</h2>
+        <p>Es kann sein, dass Drittanbieter-Links auf dieser Website Sie zu Drittanbieter-Websites führen, die nicht mit uns zusammenarbeiten. Wir sind nicht verantwortlich für die Prüfung oder Bewertung des Inhalts oder seiner Richtigkeit und wir übernehmen keine Garantie und keine Haftung oder Verantwortung für Materialien oder Websites von Drittanbietern.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 10 - BENUTZERKOMMENTARE, FEEDBACK UND ANDERE EINSENDUNGEN</h2>
+        <p>Wenn Sie Kommentare, Anregungen, Vorschläge oder andere Materialien an uns senden, erklären Sie sich damit einverstanden, dass wir diese jederzeit und ohne Einschränkung bearbeiten, vervielfältigen, veröffentlichen und verwenden dürfen.</p>
+        <p>Sie stimmen zu, dass Ihre Kommentare keine Rechte Dritter verletzen, unter anderem Urheber-, Marken-, Datenschutz- oder Persönlichkeitsrechte. Sie stimmen ferner zu, dass Ihre Kommentare kein rechtswidriges, beleidigendes oder obszönes Material enthalten.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 11 - PERSONENBEZOGENE DATEN</h2>
+        <p>Die Übermittlung von personenbezogenen Daten über die Website unterliegt unserer Datenschutzerklärung. Lesen Sie dafür unsere Datenschutzerklärung.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 12 - FEHLER, UNGENAUIGKEITEN UND AUSLASSUNGEN</h2>
+        <p>Gelegentlich kann es vorkommen, dass unsere Website typografische Fehler, Ungenauigkeiten oder Auslassungen in Bezug auf Beschreibungen, Preisgestaltung, Werbeaktionen und Verfügbarkeit enthalten. Wir behalten uns das Recht vor, jederzeit und ohne vorherige Ankündigung jegliche Fehler, Ungenauigkeiten und Auslassungen zu korrigieren und Informationen zu ändern.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 13 - VERBOTENE ANWENDUNGEN</h2>
+        <p>Zusätzlich zu anderen Verboten ist es Ihnen untersagt, die Website oder ihren Inhalt für Folgendes zu nutzen: (a) für rechtswidrige Zwecke; (b) um andere zur Durchführung ungesetzlicher Handlungen aufzufordern; (c) um gegen Vorschriften, Regeln oder Gesetze zu verstoßen; (d) um unsere Rechte an geistigem Eigentum zu verletzen; (e) um zu belästigen, zu missbrauchen oder zu diskriminieren; (f) falsche Informationen zu übermitteln; (g) um Viren oder schädlichen Code hochzuladen; (h) um persönliche Daten anderer zu sammeln; (i) zum Spammen.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 14 - HAFTUNGSAUSSCHLUSS; HAFTUNGSBESCHRÄNKUNG</h2>
+        <p>Wir übernehmen keine Garantie dafür, dass die Nutzung unserer Serviceleistung ununterbrochen, zeitgerecht, sicher oder fehlerfrei erfolgt.</p>
+        <p>Sie stimmen ausdrücklich zu, dass die Nutzung der Serviceleistung auf Ihr alleiniges Risiko erfolgt. Der Service wird Ihnen &quot;wie besehen&quot; und &quot;wie verfügbar&quot; zur Nutzung bereitgestellt, ohne jegliche Zusicherungen oder Gewährleistungen.</p>
+        <p>Auf keinen Fall sind Dokum, unsere Mitarbeiter oder Vertreter haftbar für indirekte, zufällige oder Folgeschäden jeglicher Art, einschließlich entgangener Gewinne oder Datenverlust, die sich aus der Nutzung des Dienstes ergeben.</p>
+        <p>Da einige Länder den Ausschluss oder die Haftungsbeschränkung für Folgeschäden nicht zulassen, ist unsere Haftung auf das gesetzlich maximal zulässige Maß beschränkt.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 15 - ENTSCHÄDIGUNG</h2>
+        <p>Sie verpflichten sich, Dokum und unsere Mitarbeiter, Vertreter und Dienstleister im Zusammenhang mit Ansprüchen oder Forderungen, die von Dritten aufgrund Ihrer Verletzung dieser Allgemeinen Geschäftsbedingungen geltend gemacht werden, zu entschädigen und schadlos zu halten.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 16 - SALVATORISCHE KLAUSEL</h2>
+        <p>Sollte sich herausstellen, dass eine Bestimmung dieser Allgemeinen Geschäftsbedingungen rechtswidrig, nichtig oder nicht durchsetzbar ist, ist diese Bestimmung dennoch im gesetzlich zugelassenen Umfang durchsetzbar, wobei eine solche Festlegung keine Auswirkungen auf die Gültigkeit und Durchsetzbarkeit der übrigen Bestimmungen hat.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 17 - KÜNDIGUNG</h2>
+        <p>Diese Allgemeinen Geschäftsbedingungen sind so lange gültig, bis sie von Ihnen oder uns gekündigt werden. Sie können diese Allgemeinen Geschäftsbedingungen jederzeit kündigen, indem Sie uns mitteilen, dass Sie unsere Dienste nicht mehr nutzen möchten.</p>
+        <p>Wenn Sie es nach unserem alleinigen Ermessen versäumen, irgendeine Bestimmung dieser Allgemeinen Geschäftsbedingungen zu erfüllen, können wir diese Vereinbarung jederzeit fristlos kündigen.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 18 - GESAMTE VEREINBARUNG</h2>
+        <p>Diese Allgemeinen Geschäftsbedingungen stellen die gesamte Vereinbarung zwischen Ihnen und uns dar und regeln Ihre Nutzung der Serviceleistung.</p>
+        <p>Unklarheiten bei der Auslegung dieser Allgemeinen Geschäftsbedingungen sind nicht zu unseren Lasten auszulegen.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 19 - ANWENDBARES RECHT</h2>
+        <p>Diese Allgemeinen Geschäftsbedingungen und jegliche gesonderte Vereinbarungen, durch die wir Ihnen Dienstleistungen zur Verfügung stellen, unterliegen den Gesetzen von Österreich und sind nach diesen auszulegen.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">ABSCHNITT 20 - ÄNDERUNGEN AN DEN ALLGEMEINEN GESCHÄFTSBEDINGUNGEN</h2>
+        <p>Sie können die jeweils aktuelle Version der Allgemeinen Geschäftsbedingungen jederzeit auf dieser Seite einsehen.</p>
+        <p>Wir behalten uns das Recht vor, nach unserem alleinigen Ermessen jeden Teil dieser Allgemeinen Geschäftsbedingungen jederzeit zu aktualisieren, zu ändern oder zu ersetzen. Es liegt in Ihrer Verantwortung, unsere Website regelmäßig auf Änderungen zu überprüfen. Ihre fortgesetzte Nutzung unserer Website oder Zugriff darauf nach der Veröffentlichung von Änderungen an diesen Allgemeinen Geschäftsbedingungen bedeutet, dass Sie diese Änderungen akzeptieren.</p>
+
+        <h2 className="mt-8 mb-3 text-lg font-semibold text-gray-900">KONTAKTINFORMATIONEN</h2>
+        <p>Fragen zu den Allgemeinen Geschäftsbedingungen sollten an uns gerichtet werden über die auf unserer Website angegebenen Kontaktdaten.</p>
+
+        <p className="mt-8 text-xs text-gray-500">Stand: 14.5.2026</p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -26,7 +26,7 @@ export default async function LoginPage({ searchParams }: Props) {
 
       <p className="mt-auto max-w-[430px] pt-10 text-center text-sm leading-snug text-gray-500">
         By signing in, you agree to our{' '}
-        <a href="/impressum" className="underline underline-offset-2">
+        <a href="/agb" className="underline underline-offset-2">
           Terms
         </a>{' '}
         and{' '}

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -17,7 +17,7 @@ export default function RegisterPage() {
 
       <p className="mt-auto max-w-[430px] pt-10 text-center text-sm leading-snug text-gray-500">
         By creating an account, you agree to our{' '}
-        <a href="/impressum" className="underline underline-offset-2">
+        <a href="/agb" className="underline underline-offset-2">
           Terms
         </a>{' '}
         and{' '}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -22,6 +22,9 @@ export function Footer() {
           <Link href="/datenschutz" className="transition-colors hover:text-gray-700">
             Datenschutz
           </Link>
+          <Link href="/agb" className="transition-colors hover:text-gray-700">
+            AGB
+          </Link>
         </div>
       </div>
     </footer>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,7 +13,7 @@ export async function proxy(request: NextRequest) {
   const isAuthPage = pathname.startsWith('/auth')
   const isAdminPage = pathname.startsWith('/admin')
   const isConsentPage = pathname === '/consent'
-  const isPublicPage = pathname === '/' || pathname === '/impressum' || pathname === '/datenschutz' || isConsentPage
+  const isPublicPage = pathname === '/' || pathname === '/impressum' || pathname === '/datenschutz' || pathname === '/agb' || isConsentPage
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 


### PR DESCRIPTION
## Summary
- New `/agb` route with full Terms & Conditions text (verbatim, German)
- Registered as a public page in [src/proxy.ts](src/proxy.ts) so it's reachable without auth
- Added "AGB" link in the homepage footer alongside Impressum and Datenschutz
- Repointed the "Terms" links on the login and register pages from `/impressum` → `/agb` (semantically: "Terms" = AGB, not Impressum)

## Test plan
- [x] Visit `/agb` while logged out — page renders, "← Zurück" returns to home
- [x] Verify proxy doesn't redirect `/agb` to `/auth/login`
- [x] Footer on `/` shows three links: Impressum · Datenschutz · AGB
- [x] Login & register pages: "Terms" link goes to `/agb`, "Privacy policy" still goes to `/datenschutz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)