### PR TITLE
Editor follow-ups: multi-line styling, highlight clear, size readout, image delete, drag auto-scroll (#41–#45)

### DIFF
--- a/src/app/admin/editor/editor.css
+++ b/src/app/admin/editor/editor.css
@@ -315,6 +315,39 @@
   margin: 0 auto;
 }
 
+/* #44: Lösch-✕ oben rechts im Bildblock — erst beim Hover sichtbar (wie die
+   Bibliothekseinträge). Beim PNG-Export via display:none ausgeblendet
+   (png-export.ts). */
+.latex-editor .image-block .img-remove {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #991b1b;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.latex-editor .image-block:hover .img-remove {
+  opacity: 1;
+}
+
+.latex-editor .image-block .img-remove:hover {
+  background: #fee2e2;
+  border-color: #fca5a5;
+}
+
 .latex-editor .formula-block.dragging,
 .latex-editor .image-block.dragging {
   opacity: 0.35;

--- a/src/app/admin/editor/editor.css
+++ b/src/app/admin/editor/editor.css
@@ -163,6 +163,18 @@
   cursor: pointer;
 }
 
+/* #42: „Kein Highlight" — kompakter ✕-Knopf neben dem Highlight-Picker. */
+.latex-editor .toolbar button.clear-highlight {
+  min-height: 30px;
+  padding: 7px 8px;
+  color: var(--muted);
+  font-size: 12px !important;
+}
+
+.latex-editor .toolbar button.clear-highlight:hover {
+  color: var(--editor-accent);
+}
+
 /* ------------------------------------------------- export row (slice 10) */
 
 .latex-editor .export-row {

--- a/src/components/admin/editor/EditorShell.tsx
+++ b/src/components/admin/editor/EditorShell.tsx
@@ -106,6 +106,10 @@ export function EditorShell({
   )
   const [isPending, startTransition] = useTransition()
   const [pendingUploads, setPendingUploads] = useState(0)
+  // Effektive Schriftgröße der aktuellen Editor-Auswahl (#43). Die imperative
+  // Steuerung meldet sie bei jedem selectionchange; React spiegelt sie in die
+  // Größen-Dropdown der Toolbar. Setzen mit gleichem Wert ist ein No-op-Render.
+  const [selectionFontSize, setSelectionFontSize] = useState('')
 
   // Serializes every draft-mutating server call (image uploads and saves).
   // Kept never-rejecting so one failed operation cannot wedge the chain.
@@ -151,7 +155,11 @@ export function EditorShell({
 
   useEffect(() => {
     if (!mountRef.current) return
-    const controller = createEditorController(mountRef.current, { uploadImage })
+    const controller = createEditorController(
+      mountRef.current,
+      { uploadImage },
+      { onSelectionFontSize: setSelectionFontSize }
+    )
     controllerRef.current = controller
     if (parsedDraft && parsedDraft !== 'invalid') {
       void controller.loadDocument(parsedDraft)
@@ -303,7 +311,7 @@ export function EditorShell({
           {pendingUploads > 0 ? 'Bild wird hochgeladen …' : status.text}
         </span>
       </div>
-      <EditorToolbar controllerRef={controllerRef} />
+      <EditorToolbar controllerRef={controllerRef} sizeFromSelection={selectionFontSize} />
       <ExportBar
         controllerRef={controllerRef}
         targetTree={targetTree}

--- a/src/components/admin/editor/EditorToolbar.tsx
+++ b/src/components/admin/editor/EditorToolbar.tsx
@@ -88,6 +88,15 @@ export function EditorToolbar({
           defaultValue="#fff3b0"
           onInput={(e) => ctrl()?.applyStyles({ backgroundColor: e.currentTarget.value })}
         />
+        <button
+          type="button"
+          className="clear-highlight"
+          aria-label="Kein Highlight"
+          title="Highlight entfernen"
+          onClick={() => ctrl()?.clearHighlight()}
+        >
+          ✕
+        </button>
         <label style={LABEL_STYLE}>Größe</label>
         <select
           aria-label="Schriftgröße"

--- a/src/components/admin/editor/EditorToolbar.tsx
+++ b/src/components/admin/editor/EditorToolbar.tsx
@@ -30,11 +30,19 @@ const LABEL_STYLE = { fontSize: 12, color: '#6b7280' } as const
 
 export function EditorToolbar({
   controllerRef,
+  sizeFromSelection = '',
 }: {
   controllerRef: RefObject<EditorController | null>
+  /**
+   * Effective font size of the current editor selection (#43), pushed from the
+   * controller via the shell. Reflected in the size dropdown when it matches a
+   * known option; otherwise the dropdown shows its „Größe" placeholder.
+   */
+  sizeFromSelection?: string
 }) {
   const ctrl = () => controllerRef.current
   const imageInputRef = useRef<HTMLInputElement>(null)
+  const sizeValue = FONT_SIZES.includes(sizeFromSelection) ? sizeFromSelection : ''
 
   return (
     <div className="toolbar">
@@ -100,12 +108,11 @@ export function EditorToolbar({
         <label style={LABEL_STYLE}>Größe</label>
         <select
           aria-label="Schriftgröße"
-          defaultValue=""
-          onChange={(e) => {
-            ctrl()?.applyFontSize(e.target.value)
-            // Parity with the standalone editor: the select resets itself
-            e.target.value = ''
-          }}
+          // Controlled by the live selection (#43): after applying, the cursor
+          // collapses into the block and selectionchange reflects the block's
+          // size here — superseding the reference's manual reset-to-placeholder.
+          value={sizeValue}
+          onChange={(e) => ctrl()?.applyFontSize(e.target.value)}
         >
           <option value="">Größe</option>
           {FONT_SIZES.map((size) => (

--- a/src/lib/editor/controller.ts
+++ b/src/lib/editor/controller.ts
@@ -1986,6 +1986,41 @@ export function createEditorController(
   let dropIndicator: HTMLElement | null = null
   let inlineDropCaret: HTMLElement | null = null
 
+  // #45: Auto-Scroll beim Blockziehen. Der .editor-scroll-Container hat feste
+  // Höhe; bei Dokumenten, die höher sind als das Sichtfenster, ließen sich
+  // Drop-Ziele außerhalb des sichtbaren Bereichs nicht erreichen, weil ein
+  // aktiver Drag das normale Scrollen blockiert. Solange der Zeiger in der
+  // oberen/unteren Randzone hängt, scrollt ein Intervall in fester Schrittweite.
+  const AUTO_SCROLL_EDGE = 48 // px Randzone oben/unten
+  const AUTO_SCROLL_STEP = 12 // px pro Tick
+  let autoScrollDir = 0
+  let autoScrollTimer: ReturnType<typeof setInterval> | null = null
+
+  function stopAutoScroll() {
+    if (autoScrollTimer !== null) {
+      clearInterval(autoScrollTimer)
+      autoScrollTimer = null
+    }
+    autoScrollDir = 0
+  }
+
+  function updateAutoScroll(clientY: number) {
+    const rect = editorScroll.getBoundingClientRect()
+    if (clientY < rect.top + AUTO_SCROLL_EDGE) {
+      autoScrollDir = -1
+    } else if (clientY > rect.bottom - AUTO_SCROLL_EDGE) {
+      autoScrollDir = 1
+    } else {
+      stopAutoScroll()
+      return
+    }
+    if (autoScrollTimer === null) {
+      autoScrollTimer = setInterval(() => {
+        editorScroll.scrollTop += autoScrollDir * AUTO_SCROLL_STEP
+      }, 16)
+    }
+  }
+
   function ensureDropIndicator(): HTMLElement {
     if (!dropIndicator) {
       dropIndicator = document.createElement('div')
@@ -2039,12 +2074,14 @@ export function createEditorController(
   const onDragEnd = () => {
     if (dragEl) dragEl.classList.remove('dragging')
     removeDropIndicator()
+    stopAutoScroll()
     dragEl = null
   }
 
   const onDragOver = (e: DragEvent) => {
     if (dragEl) {
       e.preventDefault()
+      updateAutoScroll(e.clientY)
       const afterEl = getDragAfterElement(editor, e.clientY)
       const indicator = ensureDropIndicator()
       if (afterEl == null) {
@@ -2075,6 +2112,7 @@ export function createEditorController(
 
   const onDrop = (e: DragEvent) => {
     hideInlineDropCaret()
+    stopAutoScroll()
     if (dragEl) {
       e.preventDefault()
       const afterEl = getDragAfterElement(editor, e.clientY)
@@ -2220,6 +2258,7 @@ export function createEditorController(
   function destroy() {
     clearInterval(fieldSweepInterval)
     clearTimeout(latexPreviewTimer)
+    stopAutoScroll()
     imageCleanupObserver.disconnect()
     document.removeEventListener('selectionchange', onSelectionChange)
     editor.removeEventListener('keydown', onKeyDown)

--- a/src/lib/editor/controller.ts
+++ b/src/lib/editor/controller.ts
@@ -110,6 +110,20 @@ export interface EditorControllerHooks {
   uploadImage(file: File): Promise<{ ok: true; imageId: string } | { ok: false; error: string }>
 }
 
+/**
+ * Optional callbacks the React shell wires to component state. Unlike the
+ * server `hooks`, these carry no side effects into the controller — they let
+ * React mirror editor state that lives outside the contenteditable surface.
+ */
+export interface EditorControllerCallbacks {
+  /**
+   * Fired on every editor selectionchange with the effective font size at the
+   * selection anchor as an integer px string (e.g. `"18"`), or `""` when it
+   * can't be determined. Drives the toolbar size dropdown (#43).
+   */
+  onSelectionFontSize?: (px: string) => void
+}
+
 export interface EditorController {
   /** `document.execCommand` wrapper (bold, italic, lists, alignment, …). */
   exec(cmd: string, value?: string): void
@@ -213,7 +227,8 @@ function errorMessage(err: unknown): string {
 
 export function createEditorController(
   container: HTMLElement,
-  hooks: EditorControllerHooks
+  hooks: EditorControllerHooks,
+  callbacks: EditorControllerCallbacks = {}
 ): EditorController {
   // --- Static skeleton (imperative DOM; the React reconciler never sees it) ---
   // The LaTeX modal is part of the skeleton (PRD: modals stay DOM-driven).
@@ -1882,10 +1897,29 @@ export function createEditorController(
   }
 
   // savedRange immer aktuell halten, solange im Editor getippt/geklickt wird
+  // Effektive Schriftgröße am Auswahlanker als Ganzzahl-px-String (#43).
+  // getComputedStyle löst die Kaskade auf, liefert also automatisch die Größe
+  // des nächstgelegenen Style-Spans bzw. — bei kollabiertem Cursor hinter einem
+  // Span oder in Normaltext — die des Blocks. '' wenn nicht ermittelbar.
+  function currentSelectionFontSize(): string {
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0 || !editor.contains(sel.anchorNode)) return ''
+    const node = sel.anchorNode
+    const el =
+      node && node.nodeType === Node.ELEMENT_NODE
+        ? (node as Element)
+        : (node?.parentElement ?? null)
+    if (!el || !editor.contains(el)) return ''
+    const match = /^(\d+(?:\.\d+)?)px$/.exec(window.getComputedStyle(el).fontSize)
+    if (!match) return ''
+    return String(Math.round(parseFloat(match[1]!)))
+  }
+
   const onSelectionChange = () => {
     const sel = window.getSelection()
     if (sel && sel.rangeCount > 0 && editor.contains(sel.anchorNode)) {
       state.savedRange = sel.getRangeAt(0).cloneRange()
+      callbacks.onSelectionFontSize?.(currentSelectionFontSize())
     }
   }
 

--- a/src/lib/editor/controller.ts
+++ b/src/lib/editor/controller.ts
@@ -126,6 +126,13 @@ export interface EditorController {
   /** Style template: color + size + optional bold. */
   applyTemplate(color: string, px: number, bold: boolean): void
   /**
+   * Removes the highlight (`background-color`) from the styled spans touched
+   * by the current selection (or, when collapsed, the highlighted span under
+   * the cursor) and unwraps any span left with no inline style. No-op while
+   * the LaTeX textarea is focused.
+   */
+  clearHighlight(): void
+  /**
    * Snapshots the current editor selection into internal state — the saved
    * range is what block insertion (LaTeX modal, later the image file
    * dialog) anchors to.
@@ -520,6 +527,59 @@ export function createEditorController(
 
   function applyTemplate(color: string, px: number, bold: boolean) {
     applyStyles({ color, fontSize: px + 'px', fontWeight: bold ? 'bold' : 'normal' })
+  }
+
+  // Ersetzt ein Element durch seine Kindknoten (für #42: Style-Span auflösen,
+  // wenn nach dem Entfernen des Highlights kein Inline-Stil mehr übrig ist).
+  function unwrapElement(el: HTMLElement) {
+    const parent = el.parentNode
+    if (!parent) return
+    while (el.firstChild) parent.insertBefore(el.firstChild, el)
+    parent.removeChild(el)
+  }
+
+  // #42: „Kein Highlight" — entfernt `background-color` aus den Style-Spans der
+  // Auswahl. Der Highlight-Picker kann nur setzen; ohne diese Umkehr stapelten
+  // sich verschachtelte gefärbte Spans. Ein Span, der danach keinen Inline-Stil
+  // mehr trägt, wird aufgelöst, damit keine leeren Wrapper zurückbleiben.
+  function clearHighlight() {
+    if (isLatexActive()) return
+    const sel = ensureEditorSelection()
+    if (!sel || sel.rangeCount === 0) return
+    const range = sel.getRangeAt(0)
+
+    const targets = new Set<HTMLElement>()
+    const addHighlightedAncestors = (start: Node | null) => {
+      let node: Node | null = start
+      while (node && node !== editor) {
+        if (node instanceof HTMLElement && node.style.backgroundColor) targets.add(node)
+        node = node.parentNode
+      }
+    }
+
+    if (range.collapsed) {
+      addHighlightedAncestors(range.startContainer)
+    } else {
+      // Nachkommen im gemeinsamen Vorfahren, die die Auswahl schneiden …
+      const root = range.commonAncestorContainer
+      const rootEl =
+        root.nodeType === Node.ELEMENT_NODE ? (root as Element) : root.parentElement
+      rootEl?.querySelectorAll<HTMLElement>('[style*="background"]').forEach((el) => {
+        if (el.style.backgroundColor && range.intersectsNode(el)) targets.add(el)
+      })
+      // … plus gehighlightete Vorfahren der Auswahlgrenzen (Span umschließt die
+      // Auswahl komplett und wird daher nicht von querySelectorAll erfasst).
+      addHighlightedAncestors(range.startContainer)
+      addHighlightedAncestors(range.endContainer)
+    }
+
+    for (const el of targets) {
+      el.style.removeProperty('background-color')
+      if (el.tagName === 'SPAN' && el.style.length === 0 && !el.className) {
+        unwrapElement(el)
+      }
+    }
+    editor.focus()
   }
 
   function formatBlock(tag: string) {
@@ -2117,6 +2177,7 @@ export function createEditorController(
     applyStyles,
     applyFontSize,
     applyTemplate,
+    clearHighlight,
     saveSelection,
     openLatexModal,
     insertInputField: () => insertField('input'),

--- a/src/lib/editor/controller.ts
+++ b/src/lib/editor/controller.ts
@@ -79,6 +79,7 @@ import {
 import {
   DocumentJsonSchema,
   JSON_IMPORT_EXAMPLE,
+  createImageRemoveButton,
   describeDocumentJsonError,
   importEditorJson,
   serializeEditorState,
@@ -1824,6 +1825,9 @@ export function createEditorController(
     img.setAttribute('contenteditable', 'false')
     block.appendChild(handle)
     block.appendChild(img)
+    // Lösch-✕ (#44) — identische Chrome wie im Import-Renderer; der Klick wird
+    // in onEditorClick delegiert.
+    block.appendChild(createImageRemoveButton(document))
     return block
   }
 
@@ -1896,7 +1900,6 @@ export function createEditorController(
     }
   }
 
-  // savedRange immer aktuell halten, solange im Editor getippt/geklickt wird
   // Effektive Schriftgröße am Auswahlanker als Ganzzahl-px-String (#43).
   // getComputedStyle löst die Kaskade auf, liefert also automatisch die Größe
   // des nächstgelegenen Style-Spans bzw. — bei kollabiertem Cursor hinter einem
@@ -1915,6 +1918,7 @@ export function createEditorController(
     return String(Math.round(parseFloat(match[1]!)))
   }
 
+  // savedRange immer aktuell halten, solange im Editor getippt/geklickt wird
   const onSelectionChange = () => {
     const sel = window.getSelection()
     if (sel && sel.rangeCount > 0 && editor.contains(sel.anchorNode)) {
@@ -1931,6 +1935,15 @@ export function createEditorController(
   // editing (copy/paste), which are click-dead in the reference.
   const onEditorClick = (e: MouseEvent) => {
     const clicked = e.target instanceof Element ? e.target : null
+    // Lösch-✕ eines Bildblocks (#44): ganzen .image-block entfernen. Delegiert
+    // wie die Pillen unten — greift auch für vom Browser geklonte Buttons.
+    const removeBtn = clicked?.closest<HTMLElement>('.img-remove')
+    if (removeBtn && editor.contains(removeBtn)) {
+      e.preventDefault()
+      e.stopPropagation()
+      removeBtn.closest<HTMLElement>('.image-block')?.remove()
+      return
+    }
     const pill = clicked?.closest<HTMLElement>('.input-field, .output-field')
     if (pill && editor.contains(pill)) {
       e.stopPropagation()
@@ -2109,6 +2122,30 @@ export function createEditorController(
     inlineDropCaret = null
   }
 
+  // #44: Löscht der Nutzer das <img> per Tastatur (Bild markieren + Entf),
+  // bleibt sonst der leere .image-block-Rahmen (Formel-Box + Drag-Handle)
+  // zurück. Wir beobachten das Entfernen von Bildknoten und räumen den dann
+  // bildlosen Block ab. Deckt jeden Löschweg ab (Entf, Backspace, Ausschneiden)
+  // — robuster als ein Entf-Keydown-Abfang. Blöcke entstehen nie ohne <img>
+  // (createImageBlockElement/Import bauen sie komplett vor dem Einfügen), daher
+  // ist „image-block ohne img" eindeutig ein gelöschtes Bild.
+  const imageCleanupObserver = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      if (m.type !== 'childList' || m.removedNodes.length === 0) continue
+      let removedImg = false
+      m.removedNodes.forEach((n) => {
+        if (n.nodeName === 'IMG' || (n instanceof Element && n.querySelector('img'))) {
+          removedImg = true
+        }
+      })
+      if (!removedImg) continue
+      const target = m.target instanceof Element ? m.target : null
+      const block = target?.closest<HTMLElement>('.image-block')
+      if (block && editor.contains(block) && !block.querySelector('img')) block.remove()
+    }
+  })
+  imageCleanupObserver.observe(editor, { childList: true, subtree: true })
+
   editor.addEventListener('keydown', onKeyDown)
   editor.addEventListener('paste', onPaste)
   editor.addEventListener('click', onEditorClick)
@@ -2183,6 +2220,7 @@ export function createEditorController(
   function destroy() {
     clearInterval(fieldSweepInterval)
     clearTimeout(latexPreviewTimer)
+    imageCleanupObserver.disconnect()
     document.removeEventListener('selectionchange', onSelectionChange)
     editor.removeEventListener('keydown', onKeyDown)
     editor.removeEventListener('paste', onPaste)

--- a/src/lib/editor/controller.ts
+++ b/src/lib/editor/controller.ts
@@ -418,11 +418,33 @@ export function createEditorController(
     if (!sel || sel.rangeCount === 0) return
     const range = sel.getRangeAt(0)
 
-    const span = document.createElement('span')
-    Object.assign(span.style, styleObj)
+    if (range.collapsed) {
+      // Keine Auswahl: leerer Style-Span mit Zero-Width-Space, Cursor rein
+      const span = document.createElement('span')
+      Object.assign(span.style, styleObj)
+      const zwsp = document.createTextNode('\u200B')
+      span.appendChild(zwsp)
+      range.insertNode(span)
+      const inside = document.createRange()
+      inside.setStart(zwsp, 1)
+      inside.collapse(true)
+      sel.removeAllRanges()
+      sel.addRange(inside)
+      return
+    }
 
-    if (!range.collapsed) {
-      // Auswahl vorhanden: wrappen, Cursor ans Ende
+    // Auswahl vorhanden: pro Textknoten den ausgew\u00E4hlten Teil in einen eigenen
+    // Style-Span wrappen (#41). Der fr\u00FChere Ansatz (`range.extractContents()`
+    // in EINEN Span) zog bei mehrzeiligen Auswahlen ganze Block-Teilb\u00E4ume
+    // heraus \u2014 Listen wurden gespalten (doppelte Nummerierung), Normaltext gar
+    // nicht gef\u00E4rbt. Textknoten \u00FCberschreiten nie eine Blockgrenze, also l\u00E4sst
+    // das Wrappen je Knoten Listen-/Block-Struktur unangetastet.
+    const textNodes = collectSelectedTextNodes(range)
+    if (textNodes.length === 0) {
+      // Reine Nicht-Text-Auswahl (z. B. nur ein Bild): altes Verhalten als
+      // Fallback, damit sich hier nichts regressiert.
+      const span = document.createElement('span')
+      Object.assign(span.style, styleObj)
       try {
         span.appendChild(range.extractContents())
       } catch {
@@ -434,17 +456,61 @@ export function createEditorController(
       after.collapse(true)
       sel.removeAllRanges()
       sel.addRange(after)
-    } else {
-      // Keine Auswahl: leerer Style-Span mit Zero-Width-Space, Cursor rein
-      const zwsp = document.createTextNode('\u200B')
-      span.appendChild(zwsp)
-      range.insertNode(span)
-      const inside = document.createRange()
-      inside.setStart(zwsp, 1)
-      inside.collapse(true)
-      sel.removeAllRanges()
-      sel.addRange(inside)
+      return
     }
+
+    let lastSpan: HTMLElement | null = null
+    for (const node of textNodes) {
+      const startOffset = node === range.startContainer ? range.startOffset : 0
+      const endOffset = node === range.endContainer ? range.endOffset : node.length
+      if (startOffset >= endOffset) continue
+      // Den ausgew\u00E4hlten Bereich zu einem eigenen Textknoten aufspalten.
+      let target = node
+      if (endOffset < target.length) target.splitText(endOffset)
+      if (startOffset > 0) target = target.splitText(startOffset)
+      const span = document.createElement('span')
+      Object.assign(span.style, styleObj)
+      target.parentNode?.insertBefore(span, target)
+      span.appendChild(target)
+      lastSpan = span
+    }
+
+    // Cursor ans Ende der Auswahl (wie im Einzelspan-Verhalten der Referenz).
+    // Bewusst KEINE Auswahl \u00FCber die Spans halten: das Textfarb-/Highlight-
+    // <input> feuert `input` w\u00E4hrend des Ziehens laufend, ein erhaltenes
+    // Selektion-Rewrap w\u00FCrde die Spans bei jedem Tick verschachteln.
+    if (lastSpan) {
+      const after = document.createRange()
+      after.setStartAfter(lastSpan)
+      after.collapse(true)
+      sel.removeAllRanges()
+      sel.addRange(after)
+    }
+  }
+
+  // Sammelt alle Textknoten, die sich mit dem Range \u00FCberschneiden (f\u00FCr das
+  // per-Knoten-Styling in #41). Reine Whitespace-Knoten (Formatierungs-
+  // whitespace zwischen Bl\u00F6cken) werden \u00FCbersprungen, damit keine losen
+  // Style-Spans direkt im Editor entstehen.
+  function collectSelectedTextNodes(range: Range): Text[] {
+    const root = range.commonAncestorContainer
+    if (root.nodeType === Node.TEXT_NODE) {
+      return range.startOffset < range.endOffset ? [root as Text] : []
+    }
+    const nodes: Text[] = []
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        if (!range.intersectsNode(node)) return NodeFilter.FILTER_REJECT
+        if (!node.nodeValue || node.nodeValue.trim() === '') return NodeFilter.FILTER_REJECT
+        return NodeFilter.FILTER_ACCEPT
+      },
+    })
+    let n = walker.nextNode()
+    while (n) {
+      nodes.push(n as Text)
+      n = walker.nextNode()
+    }
+    return nodes
   }
 
   function applyFontSize(px: string) {

--- a/src/lib/editor/document-json.test.ts
+++ b/src/lib/editor/document-json.test.ts
@@ -583,6 +583,29 @@ describe('importEditorJson', () => {
     editor.remove()
   })
 
+  it('renders the #44 image delete ✕ as editor chrome the serializer ignores', () => {
+    const editor = makeEditor()
+    importEditorJson(
+      parse({
+        version: '1.0',
+        variables: [],
+        content: [{ type: 'image', imageId: IMG_ID, alt: 'Screenshot' }],
+      }),
+      editor,
+      makeAdapters()
+    )
+    const block = editor.querySelector<HTMLElement>('.image-block')!
+    const remove = block.querySelector<HTMLButtonElement>('button.img-remove')!
+    expect(remove).not.toBeNull()
+    expect(remove.getAttribute('contenteditable')).toBe('false')
+    expect(remove.getAttribute('type')).toBe('button')
+    // The button is chrome only — serialization reads img[data-image-id] and
+    // must round-trip the block unchanged despite the extra child.
+    const json = serializeEditorState(editor, [])
+    expect(json.content).toEqual([{ type: 'image', imageId: IMG_ID, alt: 'Screenshot' }])
+    editor.remove()
+  })
+
   it('restores the slice-7 variable extras as datasets', () => {
     const editor = makeEditor()
     importEditorJson(

--- a/src/lib/editor/document-json.ts
+++ b/src/lib/editor/document-json.ts
@@ -619,6 +619,24 @@ function createInlineNodes(children: InlineNode[] | undefined, ctx: InlineContex
   return frag
 }
 
+/**
+ * The image-block delete affordance (#44) — a hover-revealed ✕ that removes
+ * the whole `.image-block`. Editor chrome like the drag-handle: invisible to
+ * the serializer (which reads only `img[data-image-id]`) and hidden during PNG
+ * export. Shared by the import renderer and the controller's live insert path
+ * so both produce identical markup; the controller wires the click.
+ */
+export function createImageRemoveButton(docEl: Document): HTMLButtonElement {
+  const btn = docEl.createElement('button')
+  btn.setAttribute('type', 'button')
+  btn.className = 'img-remove'
+  btn.setAttribute('contenteditable', 'false')
+  btn.setAttribute('aria-label', 'Bild löschen')
+  btn.title = 'Bild löschen'
+  btn.textContent = '✕'
+  return btn
+}
+
 function createBlock(
   block: EditorDocumentBlock,
   ctx: InlineContext,
@@ -691,6 +709,10 @@ function createBlock(
     img.dataset['imageId'] = block.imageId
     el.appendChild(handle)
     el.appendChild(img)
+    // Editor-Chrome wie der drag-handle (#44): Lösch-✕, das den ganzen Block
+    // entfernt. Für den Serializer unsichtbar (der liest nur img[data-image-id])
+    // und beim PNG-Export ausgeblendet (png-export.ts).
+    el.appendChild(createImageRemoveButton(docEl))
   } else if (block.type === 'code') {
     // Slice-7 extension: the editor's <pre> blocks (codeblock insert / formatBlock).
     el = docEl.createElement('pre')

--- a/src/lib/editor/png-export.ts
+++ b/src/lib/editor/png-export.ts
@@ -124,7 +124,11 @@ export async function exportAreaToPngBlob(
   editorScroll.style.maxHeight = 'none'
   editorScroll.style.overflowY = 'visible'
 
-  const handles = Array.from(exportArea.querySelectorAll<HTMLElement>('.drag-handle'))
+  // Editor-Chrome ausblenden: Drag-Handles und die Bild-Lösch-✕ (#44) dürfen
+  // nicht im PNG landen.
+  const handles = Array.from(
+    exportArea.querySelectorAll<HTMLElement>('.drag-handle, .img-remove')
+  )
   handles.forEach((h) => {
     h.dataset['prevDisplay'] = h.style.display
     h.style.display = 'none'


### PR DESCRIPTION
Works through the five editor follow-up enhancements from the #40 parity checklist, one commit per issue. All are beyond-reference improvements approved as follow-ups in #40.

## Changes

- **#41 — Multi-line selection styling.** `applyStyles` no longer extracts the whole range into one span (which split ordered lists and skipped normal multi-line text). It now wraps the selected portion of each intersecting text node in its own styled span, so block/list structure survives and color/highlight/templates reach every line.
- **#42 — Remove a highlight.** New ✕ "Kein Highlight" button + `clearHighlight()` strips `background-color` from the styled spans the selection touches (or the span under a collapsed cursor) and unwraps spans left with no style. Spans keeping color/size survive.
- **#43 — Size dropdown reflects the selection.** The controller reports the effective font size at the selection anchor (`getComputedStyle`) on every `selectionchange` via a new `EditorControllerCallbacks.onSelectionFontSize`; the shell mirrors it into state and the now-controlled size select shows it. Same-value updates are no-op re-renders.
- **#44 — Image delete + empty-frame cleanup.** Hover-revealed ✕ on the image block (shared `createImageRemoveButton`, used by both DOM-creation paths, invisible to the serializer, hidden in PNG export) removes the whole block; a `MutationObserver` drops an `.image-block` whose `<img>` was deleted by keyboard/cut so no orphan frame remains.
- **#45 — Auto-scroll while dragging blocks.** During an active block drag, `onDragOver` fixed-step scrolls `.editor-scroll` while the pointer sits in a 48px top/bottom edge zone; torn down on drop/dragend/destroy.

## Testing

- `npm run lint` — clean
- `npm test` — 332 pass (incl. a new #44 golden test that the delete button is chrome the serializer ignores)
- `npm run build` — succeeds
- Each fix additionally verified with a targeted jsdom/logic harness.

Closes #41
Closes #42
Closes #43
Closes #44
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)