### PR TITLE
feat: the interactive viewer foundation — versioned schema, content column, publish dual-write, student renderer (#64–#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ The dev project is a free playground — break it freely. The prod project has r
 
 ## Database changes
 
-Migrations are plain SQL in [supabase/](supabase/) — apply via the Supabase SQL editor or CLI. Order matters: `migration.sql`, then `add_audit_log.sql`, then `add_entitlements.sql`, then `add_editor_documents.sql`, then `add_editor_images.sql`. There is no migration runner; new migrations must be applied manually.
+Migrations are plain SQL in [supabase/](supabase/) — apply via the Supabase SQL editor or CLI. Order matters: `migration.sql`, then `add_audit_log.sql`, then `add_entitlements.sql`, then `add_editor_documents.sql`, then `add_editor_images.sql`, then `add_document_content.sql`. There is no migration runner; new migrations must be applied manually.
 
 **Workflow for a new migration:** apply to **dev first** via `mcp__supabase__apply_migration`, verify with `get_advisors` and a quick read, then have the user apply the same migration to prod manually (MCP cannot reach prod — see below).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,14 +69,17 @@ The dev project is a free playground — break it freely. The prod project has r
 
 Migrations are plain SQL in [supabase/](supabase/) — apply via the Supabase SQL editor or CLI. Order matters: `migration.sql`, then `add_audit_log.sql`, then `add_entitlements.sql`, then `add_editor_documents.sql`, then `add_editor_images.sql`, then `add_document_content.sql`. There is no migration runner; new migrations must be applied manually.
 
-**Workflow for a new migration:** apply to **dev first** via `mcp__supabase__apply_migration`, verify with `get_advisors` and a quick read, then have the user apply the same migration to prod manually (MCP cannot reach prod — see below).
+**Workflow for a new migration:** pre-flight any new CHECK against the existing rows (`SELECT DISTINCT col FROM …`) so a constraint failure surfaces before the DDL, apply to **dev first** via `mcp__supabase__apply_migration`, verify by reading the catalog back (see below — `get_advisors` is not available), then have the user apply the same migration to prod manually (MCP cannot reach prod — see below).
 
 ## Supabase MCP
 
 A Supabase MCP server is configured (`mcp__supabase__*` tools — see [.mcp.json](.mcp.json)) and is **pinned to the dev project only** via `--project-ref=elnupcpwhvfbmbpcbwrc`. Prod is intentionally unreachable through MCP; any prod change must be made by the user via the Supabase dashboard or CLI. Auth uses `SUPABASE_ACCESS_TOKEN` from the environment.
 
-Use the MCP to inspect and modify the dev project instead of asking the user to run SQL by hand: `list_tables`, `execute_sql`, `apply_migration`, `list_migrations`, `get_advisors`, `generate_typescript_types`, `get_logs`, plus edge function and branch management.
+Use the MCP to inspect and modify the dev project instead of asking the user to run SQL by hand. The server runs with `--features=database,docs`, so the tool set is exactly: `list_tables`, `list_extensions`, `list_migrations`, `apply_migration`, `execute_sql`, `search_docs`.
+
+**Nothing else exists.** In particular there is no `get_advisors`, no `generate_typescript_types`, no `get_logs`, and no edge-function or branch management — don't reach for them and don't plan a step around them. Widening `--features` in [.mcp.json](.mcp.json) is the only way to get them.
 
 - Prefer `apply_migration` over `execute_sql` for schema changes so the change is tracked.
-- Run `get_advisors` after schema changes to catch missing RLS or index issues.
-- After schema changes, regenerate types with `generate_typescript_types` and update [src/types/index.ts](src/types/index.ts) if the shape changed.
+- **Instead of `get_advisors`,** verify a schema change by querying the catalog: `information_schema.columns` for the column's type and nullability, `pg_get_constraintdef(oid)` for a constraint's actual text, `pg_constraint.convalidated` (a CHECK added `NOT VALID` silently skips existing rows — this proves it didn't), and `pg_class.relrowsecurity` + `pg_policies` to confirm RLS and its policies survived. Then run the real query the app will issue.
+- **Instead of `generate_typescript_types`,** hand-check [src/types/index.ts](src/types/index.ts) against the migration. Where a TS union mirrors a DB CHECK — `Document['file_type']` and `documents_file_type_check` — the two must list the same values, and nothing enforces that but this step.
+- Auth is `SUPABASE_ACCESS_TOKEN`, a user-scope env var interpolated at server **launch**. A stale token shows up as `Unauthorized` on every call; confirm by hitting `https://api.supabase.com/v1/projects/<ref>` with a bearer header. A freshly-set token requires restarting Claude Code — it never reaches the running server process.

--- a/DEVELOPER_OVERVIEW.md
+++ b/DEVELOPER_OVERVIEW.md
@@ -63,7 +63,7 @@ Kurs (Course)
 | `kurse` | Courses | `id`, `title`, `description`, **`published`**, `position`, `created_at` |
 | `units` | Course sections | `id`, `kurs_id` (FK), `title`, `description`, `position`, `created_at` |
 | `tasks` | Unit assignments | `id`, `unit_id` (FK), `title`, `description`, `position`, `created_at` |
-| `documents` | PDFs/images | `id`, `task_id` (FK), `title`, `description`, `file_path`, `file_type` (`pdf`\|`image`\|`image_collection`), `position`, `created_at` |
+| `documents` | PDFs/images/published interactive documents | `id`, `task_id` (FK), `title`, `description`, `file_path`, `file_type` (`pdf`\|`image`\|`image_collection`\|`interactive`, CHECK-constrained), `position`, `created_at`, `content` (JSONB, published document JSON — NULL for legacy rows) |
 | `document_images` | Image collection items | `id`, `document_id` (FK CASCADE), `file_path`, `position`, `created_at` |
 | `audit_logs` | Admin + purchase action log | `id`, `actor_id` (FK auth.users), `action` (`create`\|`update`\|`delete`\|`grant`\|`revoke`), `entity_type` (incl. `entitlement`, `editor_document`, `editor_image`), `entity_id`, `entity_title`, `metadata` (JSONB), `created_at` |
 | `entitlements` | Per-(user, unit) paid access | `id`, `user_id` (FK auth.users), `unit_id` (FK units), `granted_at`, `source` (`purchase`\|`admin`), `stripe_session_id` |
@@ -392,6 +392,7 @@ Migrations live in `supabase/`. Apply them in order — first to dev (Supabase S
 | `add_entitlements.sql` | `entitlements` table + RLS rewire so tasks/documents/storage require a purchase |
 | `add_editor_documents.sql` | `editor_documents` drafts table (admin-only RLS, `updated_at` trigger) + audit `entity_type` extension |
 | `add_editor_images.sql` | `editor_images` table (admin-only RLS, cascade with draft) + audit `entity_type` extension (`editor_image`); no storage-policy changes needed |
+| `add_document_content.sql` | `documents.content` JSONB (published document snapshot, NULL for legacy rows) + `documents_file_type_check` CHECK adding `interactive`; no RLS changes needed — the row is already entitlement-gated |
 
 ## Common Tasks
 

--- a/DEVELOPER_OVERVIEW.md
+++ b/DEVELOPER_OVERVIEW.md
@@ -160,7 +160,11 @@ src/
 │   │   ├── KursCard.tsx
 │   │   └── UnitCard.tsx
 │   ├── documents/
-│   │   └── DocumentCard.tsx
+│   │   ├── DocumentCard.tsx
+│   │   ├── InteractiveDocument.tsx # Live student render of a published document JSON + PNG fallback (error boundary)
+│   │   ├── DocumentPng.tsx        #   the stored picture: legacy 'image' render AND the interactive fallback
+│   │   ├── Watermark.tsx          #   tiled deterrent overlay (pointer-events:none — must not block selection)
+│   │   └── interactive-document.css #  student typography/pills/formula blocks (scoped to .dokum-document)
 │   ├── consent/
 │   ├── datenschutz/
 │   ├── UnitDetailClient.tsx       # Unit detail page (expandable tasks + documents)
@@ -175,7 +179,10 @@ src/
 │   ├── audit.ts                   # logAdminAction() — fire-and-forget audit log writer
 │   ├── editor/                    # LaTeX editor (PRD #28): imperative core + pure modules
 │   │   ├── controller.ts          # Imperative contenteditable controller (browser-only)
-│   │   ├── document-json.ts       # Versioned Zod schema (v1.0) + ported importer + serializer (draft JSON)
+│   │   ├── document-json.ts       # Versioned Zod schema (discriminated union over `version`) + ported importer + serializer
+│   │   ├── document-version.ts    # Upgrade-on-read: pure vN→vN+1 chain + readDocumentJson (the boundary for stored snapshots) — pure
+│   │   ├── document-render.ts     # Student renderer: document JSON → live DOM, reusing the importer + resolver; MathJax-free — pure
+│   │   ├── publish-plan.ts        # Copy-fresh-then-swap image re-homing plan for publishing (what to copy/rewrite/delete) — pure
 │   │   ├── expression-evaluator.ts # CSP-safe math tokenizer/parser — replaces new Function; errors → NaN
 │   │   ├── latex-normalise.ts     # LaTeX→expression translation + auto-expression extraction
 │   │   ├── field-resolver.ts      # Input/Output field graph: value resolution, cycle → Err, output-as-input rule — pure

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,10 @@ const eslintConfig = defineConfig([
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:
-    ".next/**",
+    // `**/` rather than a root-anchored `.next/**`: git worktrees under
+    // .claude/worktrees/ each carry their own build output, and ESLint would
+    // otherwise lint another branch's generated bundles as if they were ours.
+    "**/.next/**",
     "out/**",
     "build/**",
     "next-env.d.ts",

--- a/src/actions/admin/_shared.ts
+++ b/src/actions/admin/_shared.ts
@@ -9,11 +9,21 @@ export type DocumentFileRef = {
   document_images?: { file_path: string }[]
 }
 
+// Every stored object a set of Documents owns — the single source of truth for
+// all four cascade-delete paths (document, task, unit, kurs).
+//
+// Two document kinds own document_images: an `image_collection` (its uploaded
+// pages) and, since #66, an `interactive` document (the copies publishing
+// re-homed out of the draft). Both must be swept, or deleting the document
+// leaves their objects orphaned in the bucket forever — the rows cascade, the
+// storage objects do not.
+const KINDS_WITH_OWNED_IMAGES = new Set(['image_collection', 'interactive'])
+
 export function collectStoragePaths(documents: DocumentFileRef[]): string[] {
   return documents.flatMap((d) => {
     const paths: string[] = []
     if (d.file_path) paths.push(d.file_path)
-    if (d.file_type === 'image_collection') {
+    if (KINDS_WITH_OWNED_IMAGES.has(d.file_type)) {
       paths.push(...(d.document_images ?? []).map((i) => i.file_path))
     }
     return paths

--- a/src/actions/admin/documents.ts
+++ b/src/actions/admin/documents.ts
@@ -105,8 +105,16 @@ export async function updateDocument(docId: string, formData: FormData): Promise
     .single()
   if (fetchErr || !currentDoc) return { ok: false, error: 'Document not found.' }
 
-  // image_collection: only metadata editable (no file replacement)
-  if (currentDoc.file_type === 'image_collection') {
+  // Metadata-only kinds — no file replacement.
+  //
+  // `image_collection` because its pages are uploaded as a set, and (since
+  // #66) `interactive` because its file IS the published PNG of a draft:
+  // replacing it here would flip file_type away from 'interactive' while
+  // leaving the content JSON and the re-homed document_images behind, i.e. a
+  // document whose row disagrees with itself. Re-publishing the draft is the
+  // only way to change an interactive document's file. This is also the
+  // shape update-document collapses to entirely under #82.
+  if (currentDoc.file_type === 'image_collection' || currentDoc.file_type === 'interactive') {
     const { error } = await supabase.from('documents').update({ title, description, position }).eq('id', docId)
     if (error) return { ok: false, error: error.message }
     await logAdminAction({ actorId: user.id, action: 'update', entityType: 'document', entityId: docId, entityTitle: title })

--- a/src/actions/admin/editor-publish.ts
+++ b/src/actions/admin/editor-publish.ts
@@ -1,27 +1,48 @@
 'use server'
 
 import { STORAGE_BUCKET, MAX_FILE_SIZE_BYTES } from '@/lib/constants'
+import { readDocumentJson } from '@/lib/editor/document-version'
+import { planPublish, type PublishPlan, type StoredImageRef } from '@/lib/editor/publish-plan'
 import { EditorPublishSchema } from '@/lib/schemas'
 import type { ActionResult } from '@/types'
 import { logAdminAction } from '@/lib/audit'
 import { getAdminUser, parseForm, revalidateAdminPages, sanitise, removeStorageObjects } from './_shared'
 
 /**
- * Publishes an editor draft as a Document under a Task (PRD #28, slice 11 —
- * #39): the client-rendered PNG becomes a real Document through the existing
- * document pipeline — the storage-upload / rollback / audit / revalidation
- * flow deliberately MIRRORS the single-file branches of createDocument /
- * updateDocument (documents.ts) instead of refactoring them (approved: zero
- * blast radius on shipped flows).
+ * Publishes an editor draft as a Document (PRD #28, slice 11 — #39; extended
+ * to the interactive dual-write in #66).
  *
- * `mode: 'update'` (default) updates the linked Document's FILE + TITLE in
- * place when a live link exists — task_id/description/position stay untouched
- * ("in place" = same place; relocation is „Als neues Dokument" + manual
- * delete). Students keep the same Document entry (story 32): the id never
- * changes and /api/file/[docId] reads file_path at request time. When the
- * link is dead (Document deleted → FK SET NULL, or lost in a race) the same
- * call falls back to creating a new Document — the deleted-link fallback.
- * `mode: 'new'` („Als neues Dokument") always creates and RE-LINKS the draft.
+ * The Document row is DUAL-WRITTEN: title, `file_type = 'interactive'`, the
+ * validated content JSON and the PNG path all land in ONE statement. The
+ * student renderer prefers the JSON and falls back to the PNG inside an error
+ * boundary — a genuine per-document safety net for the release where the
+ * renderer is unproven, not a feature flag. Once proven, a cleanup pass nulls
+ * the file path and drops the PNGs with no code rewrite.
+ *
+ * The snapshot is read from the DRAFT ROW, not from the request: publish
+ * implies save (the ExportBar saves before exporting), so the stored draft is
+ * the authoritative thing to publish and the PNG can never diverge from it.
+ * An unreadable draft is refused rather than published half-understood.
+ *
+ * IMAGES ARE COPIED, NEVER MOVED. `editor_images` rows cascade with their
+ * draft and the draft must stay editable and re-publishable, so a published
+ * document that pointed at draft images would blank out the moment its draft
+ * was deleted. The ordering — copy, insert rows, swap in one statement, then
+ * delete the previous publish's rows and objects — is the same ordering this
+ * action already used for the PNG: fail before the swap and only orphans
+ * exist while the live document is untouched; fail during cleanup and only
+ * stale objects remain while the document is correct. The decisions are made
+ * up front by the pure `planPublish` (publish-plan.ts); this action only
+ * executes them.
+ *
+ * `mode: 'update'` (default) updates the linked Document in place when a live
+ * link exists — task_id/description/position stay untouched ("in place" =
+ * same place; relocation is „Als neues Dokument" + manual delete). Students
+ * keep the same Document entry (story 32) and the id never changes, so
+ * bookmarks and future links to it stay valid. When the link is dead
+ * (Document deleted → FK SET NULL, or lost in a race) the same call falls
+ * back to creating a new Document. `mode: 'new'` („Als neues Dokument")
+ * always creates and RE-LINKS the draft.
  *
  * The draft row is not touched on update-in-place (its updated_at must not
  * reorder the draft list); on the create paths only published_document_id
@@ -54,12 +75,30 @@ export async function publishEditorDraft(
 
   const { data: draft, error: draftErr } = await supabase
     .from('editor_documents')
-    .select('id, published_document_id')
+    .select('id, content, published_document_id')
     .eq('id', draft_id)
     .single()
   if (draftErr || !draft) return { ok: false, error: 'Entwurf nicht gefunden.' }
 
-  // ── Update-in-place path (default when a LIVE link exists) ────────────────
+  // Upgrade-on-read (#64): the stored draft may carry any supported version;
+  // what gets published is always the newest. A snapshot that cannot be read
+  // is refused whole — publishing a half-understood document would hand a
+  // paying student a document missing whatever the reader did not recognise.
+  const snapshot = readDocumentJson(draft.content)
+  if (!snapshot.ok) {
+    return { ok: false, error: `Entwurf konnte nicht veröffentlicht werden: ${snapshot.error}` }
+  }
+
+  const { data: draftImages, error: draftImgErr } = await supabase
+    .from('editor_images')
+    .select('id, file_path')
+    .eq('editor_document_id', draft_id)
+  if (draftImgErr) {
+    return { ok: false, error: `Bilder des Entwurfs konnten nicht gelesen werden: ${draftImgErr.message}` }
+  }
+
+  // ── Resolve the target: update in place, or create ────────────────────────
+  let target: { id: string; file_path: string | null } | null = null
   if (mode === 'update' && draft.published_document_id) {
     const { data: linkedDoc, error: linkedErr } = await supabase
       .from('documents')
@@ -77,59 +116,128 @@ export async function publishEditorDraft(
         error: `Verknüpftes Dokument konnte nicht gelesen werden: ${linkedErr.message}`,
       }
     }
-
-    if (linkedDoc) {
-      const newPath = `documents/${user.id}/${Date.now()}-${sanitise(title)}.png`
-
-      const { error: uploadErr } = await supabase.storage
-        .from(STORAGE_BUCKET)
-        .upload(newPath, file, { contentType: 'image/png', upsert: false })
-      if (uploadErr) return { ok: false, error: `Upload fehlgeschlagen: ${uploadErr.message}` }
-
-      const { error: dbErr } = await supabase
-        .from('documents')
-        .update({ title, file_path: newPath, file_type: 'image' })
-        .eq('id', linkedDoc.id)
-      if (dbErr) {
-        await removeStorageObjects(supabase, [newPath], 'publishEditorDraft update rollback')
-        return { ok: false, error: `Dokument konnte nicht aktualisiert werden: ${dbErr.message}` }
-      }
-
-      if (linkedDoc.file_path) {
-        await removeStorageObjects(supabase, [linkedDoc.file_path], 'publishEditorDraft old-file cleanup')
-      }
-
-      await logAdminAction({
-        actorId: user.id,
-        action: 'update',
-        entityType: 'document',
-        entityId: linkedDoc.id,
-        entityTitle: title,
-        metadata: { editor_document_id: draft_id, published_in_place: true },
-      })
-      revalidateAdminPages()
-      return { ok: true, data: { documentId: linkedDoc.id, mode: 'updated' } }
-    }
-    // Linked Document vanished (deleted → FK SET NULL, or race) → fall
-    // through to the create path instead of erroring (acceptance criterion).
+    target = linkedDoc ?? null
   }
 
-  // ── Create path (first publish, „Als neues Dokument", dead-link fallback) ──
-  const storagePath = `documents/${user.id}/${Date.now()}-${sanitise(title)}.png`
+  // The previous publish's copies — the only rows and objects this publish is
+  // allowed to delete, and only after the swap succeeds.
+  let previousImages: StoredImageRef[] = []
+  if (target) {
+    const { data, error } = await supabase
+      .from('document_images')
+      .select('id, file_path')
+      .eq('document_id', target.id)
+    if (error) {
+      return { ok: false, error: `Bilder des Dokuments konnten nicht gelesen werden: ${error.message}` }
+    }
+    previousImages = data ?? []
+  }
+
+  const stamp = Date.now()
+  const planned = planPublish({
+    content: snapshot.doc,
+    draftImages: draftImages ?? [],
+    previousImages,
+    mintImageId: () => crypto.randomUUID(),
+    mintImagePath: ({ fromPath, index }) =>
+      `documents/${user.id}/${stamp}-${index}-${sanitise(title, 40)}${extensionOf(fromPath)}`,
+  })
+  if (!planned.ok) return { ok: false, error: planned.error }
+  const plan = planned.plan
+
+  // ── Step 1: build everything new (nothing live is touched yet) ────────────
+  const pngPath = `documents/${user.id}/${stamp}-${sanitise(title)}.png`
 
   const { error: uploadErr } = await supabase.storage
     .from(STORAGE_BUCKET)
-    .upload(storagePath, file, { contentType: 'image/png', upsert: false })
+    .upload(pngPath, file, { contentType: 'image/png', upsert: false })
   if (uploadErr) return { ok: false, error: `Upload fehlgeschlagen: ${uploadErr.message}` }
 
-  const { data: insertedDoc, error: insertErr } = await supabase
+  const freshPaths: string[] = [pngPath]
+  for (const copy of plan.copies) {
+    const { error } = await supabase.storage.from(STORAGE_BUCKET).copy(copy.fromPath, copy.toPath)
+    if (error) {
+      await removeStorageObjects(supabase, freshPaths, 'publishEditorDraft image-copy rollback')
+      return { ok: false, error: `Bild konnte nicht übernommen werden: ${error.message}` }
+    }
+    freshPaths.push(copy.toPath)
+  }
+
+  // ── Update-in-place path ──────────────────────────────────────────────────
+  if (target) {
+    // Step 2: the new document-image rows. They hang off the live Document
+    // while the swap is still pending, which is harmless — an interactive
+    // document does not render document_images, only its content JSON does.
+    const insertErr = await insertPlannedImages(supabase, plan, target.id)
+    if (insertErr) {
+      await removeStorageObjects(supabase, freshPaths, 'publishEditorDraft image-row rollback')
+      return { ok: false, error: `Bilder konnten nicht gespeichert werden: ${insertErr}` }
+    }
+
+    // Step 4: THE SWAP — content and file path in one statement.
+    const { error: dbErr } = await supabase
+      .from('documents')
+      .update({ title, file_path: pngPath, file_type: 'interactive', content: plan.content })
+      .eq('id', target.id)
+    if (dbErr) {
+      await deleteImageRows(supabase, plan.inserts.map((r) => r.id), 'publishEditorDraft swap rollback')
+      await removeStorageObjects(supabase, freshPaths, 'publishEditorDraft swap rollback')
+      return { ok: false, error: `Dokument konnte nicht aktualisiert werden: ${dbErr.message}` }
+    }
+
+    // Step 5: the previous publish, last. Everything from here on is
+    // best-effort — the document is already correct, and a failure leaves
+    // only stale objects behind.
+    await deleteImageRows(supabase, plan.stale.imageIds, 'publishEditorDraft stale-row cleanup')
+    await removeStorageObjects(supabase, plan.stale.paths, 'publishEditorDraft stale-image cleanup')
+    if (target.file_path) {
+      await removeStorageObjects(supabase, [target.file_path], 'publishEditorDraft old-file cleanup')
+    }
+
+    await logAdminAction({
+      actorId: user.id,
+      action: 'update',
+      entityType: 'document',
+      entityId: target.id,
+      entityTitle: title,
+      metadata: {
+        editor_document_id: draft_id,
+        published_in_place: true,
+        file_type: 'interactive',
+        images_rehomed: plan.copies.length,
+        images_retired: plan.stale.imageIds.length,
+      },
+    })
+    revalidateAdminPages()
+    return { ok: true, data: { documentId: target.id, mode: 'updated' } }
+  }
+
+  // ── Create path (first publish, „Als neues Dokument", dead-link fallback) ──
+  const { data: insertedDoc, error: docInsertErr } = await supabase
     .from('documents')
-    .insert({ task_id, title, description: null, file_path: storagePath, file_type: 'image', position: 0 })
+    .insert({
+      task_id,
+      title,
+      description: null,
+      file_path: pngPath,
+      file_type: 'interactive',
+      content: plan.content,
+      position: 0,
+    })
     .select('id')
     .single()
-  if (insertErr || !insertedDoc) {
-    await removeStorageObjects(supabase, [storagePath], 'publishEditorDraft create rollback')
-    return { ok: false, error: `Dokument konnte nicht angelegt werden: ${insertErr?.message ?? 'Unbekannter Fehler'}` }
+  if (docInsertErr || !insertedDoc) {
+    await removeStorageObjects(supabase, freshPaths, 'publishEditorDraft create rollback')
+    return {
+      ok: false,
+      error: `Dokument konnte nicht angelegt werden: ${docInsertErr?.message ?? 'Unbekannter Fehler'}`,
+    }
+  }
+
+  const imgErr = await insertPlannedImages(supabase, plan, insertedDoc.id)
+  if (imgErr) {
+    await rollbackCreatedDocument(supabase, insertedDoc.id, freshPaths, 'publishEditorDraft image-row rollback')
+    return { ok: false, error: `Bilder konnten nicht gespeichert werden: ${imgErr}` }
   }
 
   const { error: linkErr } = await supabase
@@ -138,10 +246,12 @@ export async function publishEditorDraft(
     .eq('id', draft_id)
   if (linkErr) {
     // Full rollback: an unlinked Document would duplicate on the next publish.
-    const { error: delErr } = await supabase.from('documents').delete().eq('id', insertedDoc.id)
-    if (delErr) console.error('[publishEditorDraft link rollback] document delete failed:', delErr)
-    await removeStorageObjects(supabase, [storagePath], 'publishEditorDraft link rollback')
-    return { ok: false, error: `Entwurf konnte nicht mit dem Dokument verknüpft werden: ${linkErr.message}` }
+    // The image rows go with it through the document_id cascade.
+    await rollbackCreatedDocument(supabase, insertedDoc.id, freshPaths, 'publishEditorDraft link rollback')
+    return {
+      ok: false,
+      error: `Entwurf konnte nicht mit dem Dokument verknüpft werden: ${linkErr.message}`,
+    }
   }
 
   await logAdminAction({
@@ -150,7 +260,11 @@ export async function publishEditorDraft(
     entityType: 'document',
     entityId: insertedDoc.id,
     entityTitle: title,
-    metadata: { editor_document_id: draft_id },
+    metadata: {
+      editor_document_id: draft_id,
+      file_type: 'interactive',
+      images_rehomed: plan.copies.length,
+    },
   })
   // The link change is a draft mutation of its own (operator story 35).
   await logAdminAction({
@@ -162,4 +276,52 @@ export async function publishEditorDraft(
   })
   revalidateAdminPages()
   return { ok: true, data: { documentId: insertedDoc.id, mode: 'created' } }
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+type SupabaseClient = Awaited<ReturnType<typeof getAdminUser>>['supabase']
+
+/** `.png` / `.jpg` / … of a storage path; empty when it carries no extension. */
+function extensionOf(path: string): string {
+  const match = /\.[a-zA-Z0-9]+$/.exec(path)
+  return match ? match[0] : ''
+}
+
+/**
+ * Inserts the planned `document_images` rows with the ids the plan already
+ * rewrote the snapshot to. Returns an error message, or null on success (and
+ * on an empty plan).
+ */
+async function insertPlannedImages(
+  supabase: SupabaseClient,
+  plan: PublishPlan,
+  documentId: string
+): Promise<string | null> {
+  if (plan.inserts.length === 0) return null
+  const { error } = await supabase
+    .from('document_images')
+    .insert(plan.inserts.map((row) => ({ ...row, document_id: documentId })))
+  return error ? error.message : null
+}
+
+async function deleteImageRows(
+  supabase: SupabaseClient,
+  ids: string[],
+  context: string
+): Promise<void> {
+  if (ids.length === 0) return
+  const { error } = await supabase.from('document_images').delete().in('id', ids)
+  if (error) console.error(`[${context}] document_images delete failed:`, error)
+}
+
+async function rollbackCreatedDocument(
+  supabase: SupabaseClient,
+  documentId: string,
+  paths: string[],
+  context: string
+): Promise<void> {
+  const { error } = await supabase.from('documents').delete().eq('id', documentId)
+  if (error) console.error(`[${context}] document delete failed:`, error)
+  await removeStorageObjects(supabase, paths, context)
 }

--- a/src/app/admin/documents/new/page.tsx
+++ b/src/app/admin/documents/new/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { getDocumentById, getAllKurseDeep } from '@/lib/dal'
 import { DocumentPageClient } from '@/components/admin/DocumentPageClient'
 import { AdminSubpageNav } from '@/components/admin/AdminSubpageNav'
+import type { Document as DocumentRow } from '@/types'
 
 export default async function NewDocumentPage({
   searchParams,
@@ -11,11 +12,28 @@ export default async function NewDocumentPage({
   const { taskId, editId } = await searchParams
 
   let defaultTaskId = taskId ?? ''
-  let editDefaults: { title: string; description: string | null; position: number; file_path: string | null; file_type: 'pdf' | 'image' | 'image_collection' } | undefined
+  // 'interactive' is produced by publishing an editor draft (#66), never
+  // uploaded through this form — an interactive document opened here keeps
+  // its metadata fields and simply offers no file kind.
+  let editDefaults:
+    | {
+        title: string
+        description: string | null
+        position: number
+        file_path: string | null
+        file_type?: Exclude<DocumentRow['file_type'], 'interactive'>
+      }
+    | undefined
   if (editId) {
     const data = await getDocumentById(editId)
     if (data) {
-      editDefaults = { title: data.title, description: data.description, position: data.position, file_path: data.file_path, file_type: data.file_type }
+      editDefaults = {
+        title: data.title,
+        description: data.description,
+        position: data.position,
+        file_path: data.file_path,
+        file_type: data.file_type === 'interactive' ? undefined : data.file_type,
+      }
       defaultTaskId = data.task_id
     }
   }

--- a/src/components/UnitDetailClient.tsx
+++ b/src/components/UnitDetailClient.tsx
@@ -155,7 +155,12 @@ export default function UnitDetailClient({ tasks, openTaskId, watermarkId }: { t
                                 ))}
                               </div>
                             </div>
-                          ) : doc.file_type === 'image' ? (
+                          ) : doc.file_type === 'image' || doc.file_type === 'interactive' ? (
+                            // 'interactive' is dual-written (#66): the row
+                            // carries the document JSON AND the exported PNG.
+                            // Until the live renderer lands (#67) the PNG is
+                            // what students see — deliberately no visible
+                            // difference from a published 'image'.
                             <div>
                               <p className="text-sm font-medium text-gray-800">{doc.title}</p>
                               {doc.description && (

--- a/src/components/UnitDetailClient.tsx
+++ b/src/components/UnitDetailClient.tsx
@@ -2,6 +2,9 @@
 
 import { useState } from 'react'
 import type { Task, DocumentWithImages } from '@/types'
+import { DocumentPng } from '@/components/documents/DocumentPng'
+import { InteractiveDocument } from '@/components/documents/InteractiveDocument'
+import { Watermark } from '@/components/documents/Watermark'
 import Lightbox from 'yet-another-react-lightbox'
 import Zoom from 'yet-another-react-lightbox/plugins/zoom'
 import 'yet-another-react-lightbox/styles.css'
@@ -21,39 +24,6 @@ function trackMiniCase(docId: string) {
   const ids = raw ? decodeURIComponent(raw).split(',').filter(Boolean) : []
   const next = [docId, ...ids.filter((id) => id !== docId)].slice(0, 4)
   document.cookie = `recent_minicases=${encodeURIComponent(next.join(','))}; path=/; max-age=${60 * 60 * 24 * 30}`
-}
-
-function Watermark({ id }: { id: string }) {
-  return (
-    <div
-      aria-hidden="true"
-      style={{
-        position: 'absolute', inset: 0,
-        overflow: 'hidden', userSelect: 'none',
-        cursor: 'default',
-      }}
-    >
-      {Array.from({ length: 24 }, (_, i) => (
-        <span
-          key={i}
-          style={{
-            position: 'absolute',
-            top: `${(Math.floor(i / 4) * 22) + 5}%`,
-            left: `${((i % 4) * 28) - 8}%`,
-            transform: 'rotate(-35deg)',
-            fontFamily: 'monospace',
-            fontSize: '13px',
-            fontWeight: 'bold',
-            color: 'rgba(0,0,0,0.08)',
-            whiteSpace: 'nowrap',
-            mixBlendMode: 'multiply',
-          }}
-        >
-          {id}
-        </span>
-      ))}
-    </div>
-  )
 }
 
 export default function UnitDetailClient({ tasks, openTaskId, watermarkId }: { tasks: TaskWithDocs[]; openTaskId?: string; watermarkId: string }) {
@@ -155,33 +125,33 @@ export default function UnitDetailClient({ tasks, openTaskId, watermarkId }: { t
                                 ))}
                               </div>
                             </div>
-                          ) : doc.file_type === 'image' || doc.file_type === 'interactive' ? (
-                            // 'interactive' is dual-written (#66): the row
-                            // carries the document JSON AND the exported PNG.
-                            // Until the live renderer lands (#67) the PNG is
-                            // what students see — deliberately no visible
-                            // difference from a published 'image'.
+                          ) : doc.file_type === 'interactive' && doc.content != null ? (
+                            // A published editor document renders LIVE (#67):
+                            // real text, typeset formulas, resolved values.
+                            // The dual-written PNG stays as the per-document
+                            // fallback, handled inside InteractiveDocument.
                             <div>
                               <p className="text-sm font-medium text-gray-800">{doc.title}</p>
                               {doc.description && (
                                 <p className="text-xs text-gray-500">{doc.description}</p>
                               )}
-                              <div className="mt-2 flex w-full justify-center">
-                                <div
-                                  className="relative inline-block max-w-full overflow-hidden rounded-md"
-                                  onContextMenu={(e) => e.preventDefault()}
-                                >
-                                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                                  <img
-                                    src={`/api/file/${doc.id}`}
-                                    alt={doc.title}
-                                    className="block max-w-full max-h-[600px] select-none"
-                                    style={{ pointerEvents: 'none', userSelect: 'none', WebkitUserDrag: 'none' } as React.CSSProperties}
-                                    draggable={false}
-                                  />
-                                  <Watermark id={watermarkId} />
-                                </div>
-                              </div>
+                              <InteractiveDocument
+                                docId={doc.id}
+                                title={doc.title}
+                                content={doc.content}
+                                watermarkId={watermarkId}
+                              />
+                            </div>
+                          ) : doc.file_type === 'image' || doc.file_type === 'interactive' ? (
+                            // A legacy image document, and an interactive one
+                            // whose snapshot was never stored — both are just
+                            // the picture, exactly as they render today.
+                            <div>
+                              <p className="text-sm font-medium text-gray-800">{doc.title}</p>
+                              {doc.description && (
+                                <p className="text-xs text-gray-500">{doc.description}</p>
+                              )}
+                              <DocumentPng docId={doc.id} title={doc.title} watermarkId={watermarkId} />
                             </div>
                           ) : (
                             <div className="flex items-center justify-between gap-4">

--- a/src/components/admin/editor/EditorShell.tsx
+++ b/src/components/admin/editor/EditorShell.tsx
@@ -4,11 +4,8 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState, useTransition } from 'react'
 import { createEditorDraft, updateEditorDraft, uploadEditorImage } from '@/actions/admin'
 import { createEditorController, type EditorController } from '@/lib/editor/controller'
-import {
-  DocumentJsonSchema,
-  withDocumentMeta,
-  type EditorDocumentJson,
-} from '@/lib/editor/document-json'
+import { withDocumentMeta, type LatestEditorDocumentJson } from '@/lib/editor/document-json'
+import { readDocumentJson } from '@/lib/editor/document-version'
 import type { EditorTargetKurs } from '@/types'
 import { EditorToolbar } from './EditorToolbar'
 import { ExportBar } from './ExportBar'
@@ -85,11 +82,16 @@ export function EditorShell({
   // draft) — a router.refresh() re-render must never re-import over live
   // editing state. Invalid content becomes an error status instead of a
   // broken editor.
-  const [parsedDraft] = useState<EditorDocumentJson | 'invalid' | null>(() => {
+  // Upgrade-on-read (#64): a stored draft may carry any supported version;
+  // the controller only ever receives the newest. A snapshot that cannot be
+  // read is refused whole, with the boundary's own German reason.
+  const [parsedDraft] = useState<LatestEditorDocumentJson | { invalid: string } | null>(() => {
     if (!initialDraft) return null
-    const parsed = DocumentJsonSchema.safeParse(initialDraft.content)
-    return parsed.success ? parsed.data : 'invalid'
+    const parsed = readDocumentJson(initialDraft.content)
+    return parsed.ok ? parsed.doc : { invalid: parsed.error }
   })
+  const draftError = parsedDraft !== null && 'invalid' in parsedDraft ? parsedDraft.invalid : null
+  const draftDocument = parsedDraft !== null && !('invalid' in parsedDraft) ? parsedDraft : null
 
   const [title, setTitle] = useState(initialDraft?.title ?? 'Unbenannt')
   // ExportBar Term field (slice 10) — the only draft-persisted export state
@@ -97,11 +99,11 @@ export function EditorShell({
   // reach this state, so an imported meta.term is ignored until the draft is
   // saved and reopened (documented limitation).
   const [term, setTerm] = useState(() =>
-    parsedDraft && parsedDraft !== 'invalid' ? (parsedDraft.meta?.term ?? '') : ''
+    draftDocument?.meta?.term ?? ''
   )
   const [status, setStatus] = useState<SaveStatus>(() =>
-    parsedDraft === 'invalid'
-      ? { kind: 'error', text: 'Entwurf konnte nicht geladen werden: ungültiges Dokumentformat.' }
+    draftError !== null
+      ? { kind: 'error', text: `Entwurf konnte nicht geladen werden: ${draftError}` }
       : { kind: 'idle', text: '' }
   )
   const [isPending, startTransition] = useTransition()
@@ -161,8 +163,8 @@ export function EditorShell({
       { onSelectionFontSize: setSelectionFontSize }
     )
     controllerRef.current = controller
-    if (parsedDraft && parsedDraft !== 'invalid') {
-      void controller.loadDocument(parsedDraft)
+    if (draftDocument) {
+      void controller.loadDocument(draftDocument)
     }
     return () => {
       controller.destroy()

--- a/src/components/documents/DocumentPng.tsx
+++ b/src/components/documents/DocumentPng.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { Watermark } from './Watermark'
+
+/**
+ * The stored picture of a document, served through the signed-file proxy.
+ *
+ * Two callers, deliberately one implementation: it is how a legacy `image`
+ * document renders, and it is the per-document runtime fallback for an
+ * interactive document the app cannot render (#67). Sharing the markup is
+ * what makes the fallback indistinguishable from the real thing — a student
+ * hitting it sees the document, not a degraded version of it.
+ */
+export function DocumentPng({
+  docId,
+  title,
+  watermarkId,
+}: {
+  docId: string
+  title: string
+  watermarkId: string
+}) {
+  return (
+    <div className="mt-2 flex w-full justify-center">
+      <div
+        className="relative inline-block max-w-full overflow-hidden rounded-md"
+        onContextMenu={(e) => e.preventDefault()}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={`/api/file/${docId}`}
+          alt={title}
+          className="block max-w-full max-h-[600px] select-none"
+          style={
+            {
+              pointerEvents: 'none',
+              userSelect: 'none',
+              WebkitUserDrag: 'none',
+            } as React.CSSProperties
+          }
+          draggable={false}
+        />
+        <Watermark id={watermarkId} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/documents/InteractiveDocument.tsx
+++ b/src/components/documents/InteractiveDocument.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { Component, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { renderDocumentJson } from '@/lib/editor/document-render'
+import { readDocumentJson } from '@/lib/editor/document-version'
+import { loadMathJax } from '@/lib/editor/mathjax-loader'
+import { DocumentPng } from './DocumentPng'
+import { Watermark } from './Watermark'
+import './interactive-document.css'
+
+/**
+ * A published interactive document, rendered live for students (#67).
+ *
+ * The PNG is a REAL PER-DOCUMENT RUNTIME FALLBACK, not a feature flag. If this
+ * document cannot be rendered — a snapshot newer than this build, a failed
+ * upgrade, an unrecognised node — the student gets the stored picture and the
+ * failure is logged. What must never happen is a PARTIAL render: silently
+ * dropping a node means someone who paid for this material misses a whole
+ * section with no indication that anything is missing.
+ *
+ * There are three ways rendering can fail and all three land on the picture:
+ * the read boundary refusing the snapshot, `renderDocumentJson` throwing, and
+ * a render-phase error anywhere below — which is why the class boundary
+ * exists as well as the try/catch (an error thrown inside an effect never
+ * reaches an error boundary on its own).
+ *
+ * MathJax is the one failure that does NOT fall back: a formula that cannot
+ * be typeset keeps its LaTeX source visible and the rest of the document
+ * stays readable, which is strictly better than replacing a whole readable
+ * document with a picture over one bad formula.
+ */
+export function InteractiveDocument({
+  docId,
+  title,
+  content,
+  watermarkId,
+}: {
+  docId: string
+  title: string
+  content: unknown
+  watermarkId: string
+}) {
+  const fallback = <DocumentPng docId={docId} title={title} watermarkId={watermarkId} />
+  return (
+    <DocumentRenderBoundary docId={docId} fallback={fallback}>
+      <LiveDocument docId={docId} content={content} watermarkId={watermarkId} fallback={fallback} />
+    </DocumentRenderBoundary>
+  )
+}
+
+function LiveDocument({
+  docId,
+  content,
+  watermarkId,
+  fallback,
+}: {
+  docId: string
+  content: unknown
+  watermarkId: string
+  fallback: ReactNode
+}) {
+  // Upgrade-on-read (#64) is PURE, so it happens during render: an older
+  // snapshot is migrated, an unreadable one is refused whole. That covers
+  // every documented fallback reason — unknown version, failed upgrade,
+  // unrecognised node — without a round-trip through state.
+  const snapshot = useMemo(() => readDocumentJson(content), [content])
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const [renderFailed, setRenderFailed] = useState(false)
+
+  useEffect(() => {
+    if (!snapshot.ok) {
+      console.error(`[InteractiveDocument ${docId}] Snapshot abgelehnt, PNG-Fallback:`, snapshot.error)
+      return
+    }
+    const host = hostRef.current
+    if (!host) return
+    let cancelled = false
+
+    try {
+      const { renderTargets } = renderDocumentJson(snapshot.doc, host, {
+        imageUrl: (imageId) => `/api/image/${imageId}`,
+      })
+      void typesetFormulas(renderTargets, () => cancelled)
+    } catch (err) {
+      // Leave nothing half-drawn behind before handing over to the picture.
+      host.replaceChildren()
+      console.error(`[InteractiveDocument ${docId}] Rendern fehlgeschlagen, PNG-Fallback:`, err)
+      // The failure is discovered while synchronising with the DOM, so it has
+      // to travel back into React — deferred by a microtask rather than set
+      // synchronously here, which would cascade renders.
+      void Promise.resolve().then(() => {
+        if (!cancelled) setRenderFailed(true)
+      })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [snapshot, docId])
+
+  if (!snapshot.ok || renderFailed) return <>{fallback}</>
+
+  return (
+    <div className="relative mt-2">
+      <div ref={hostRef} className="dokum-document" />
+      <Watermark id={watermarkId} />
+    </div>
+  )
+}
+
+/**
+ * Typesets each formula with the BUNDLED MathJax — no CDN, no `eval`, and so
+ * no CSP change. The renderer deliberately stops at the resolved LaTeX so it
+ * stays pure and jsdom-testable; this is the browser half.
+ */
+async function typesetFormulas(
+  targets: HTMLElement[],
+  isCancelled: () => boolean
+): Promise<void> {
+  let mathJax: Awaited<ReturnType<typeof loadMathJax>>
+  try {
+    mathJax = await loadMathJax()
+  } catch (err) {
+    // The resolved LaTeX source is already in the element — readable, if ugly.
+    console.error('[InteractiveDocument] MathJax konnte nicht geladen werden:', err)
+    return
+  }
+
+  for (const target of targets) {
+    if (isCancelled()) return
+    const latex = target.dataset['latex'] ?? ''
+    try {
+      const svg = await mathJax.tex2svgPromise(latex, { display: true })
+      if (isCancelled()) return
+      target.replaceChildren(svg)
+    } catch {
+      const box = target.ownerDocument.createElement('div')
+      box.className = 'formula-error'
+      box.textContent = latex
+      target.replaceChildren(box)
+    }
+  }
+}
+
+/**
+ * Catches render-phase errors from the live document and shows the picture
+ * instead. The effect-level try/catch above cannot cover these: React does
+ * not route errors thrown during render through the component that scheduled
+ * them, and an effect's throw never reaches a boundary at all — so both
+ * mechanisms are needed to make "never partial" actually true.
+ */
+class DocumentRenderBoundary extends Component<
+  { docId: string; fallback: ReactNode; children: ReactNode },
+  { failed: boolean }
+> {
+  override state = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  override componentDidCatch(error: Error) {
+    console.error(`[InteractiveDocument ${this.props.docId}] Renderfehler, PNG-Fallback:`, error)
+  }
+
+  override render() {
+    return this.state.failed ? this.props.fallback : this.props.children
+  }
+}

--- a/src/components/documents/Watermark.tsx
+++ b/src/components/documents/Watermark.tsx
@@ -1,0 +1,44 @@
+/**
+ * The tiled, low-contrast watermark laid over paid document content.
+ *
+ * A DETERRENT, not a lock — the same stance interactive documents take on
+ * text: real selectable, copyable text is the better experience, and the
+ * watermark exists to make casual redistribution traceable rather than
+ * impossible. It is therefore `pointer-events: none`, so it never gets in the
+ * way of selecting the text underneath it (#67).
+ */
+export function Watermark({ id }: { id: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        overflow: 'hidden',
+        userSelect: 'none',
+        pointerEvents: 'none',
+        cursor: 'default',
+      }}
+    >
+      {Array.from({ length: 24 }, (_, i) => (
+        <span
+          key={i}
+          style={{
+            position: 'absolute',
+            top: `${Math.floor(i / 4) * 22 + 5}%`,
+            left: `${(i % 4) * 28 - 8}%`,
+            transform: 'rotate(-35deg)',
+            fontFamily: 'monospace',
+            fontSize: '13px',
+            fontWeight: 'bold',
+            color: 'rgba(0,0,0,0.08)',
+            whiteSpace: 'nowrap',
+            mixBlendMode: 'multiply',
+          }}
+        >
+          {id}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/components/documents/interactive-document.css
+++ b/src/components/documents/interactive-document.css
@@ -1,0 +1,174 @@
+/*
+ * Student-facing styling for a live interactive document (#67).
+ *
+ * Scoped to `.dokum-document`, deliberately NOT a reuse of the admin editor's
+ * stylesheet: that one styles an editing surface (hover affordances, drag
+ * handles, caption placeholders, a fixed-width page) and the student surface
+ * has none of that and has to work on a phone. What IS shared is the visual
+ * language — the same accent-bar formula block and the same input/output pill
+ * colours — so a student recognises the document the author built.
+ *
+ * Tailwind preflight zeroes the element margins and list styles this content
+ * relies on, so the block defaults are restored explicitly, exactly as the
+ * editor stylesheet does for its own surface.
+ */
+
+.dokum-document {
+  font-size: 17px;
+  line-height: 1.55;
+  color: #111827;
+  /* Real, selectable, copyable text is a deliberate product choice for
+     interactive documents; the watermark is a deterrent, not a lock. */
+  user-select: text;
+  overflow-wrap: break-word;
+}
+
+.dokum-document h1 {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: var(--brand, #00338d);
+  margin: 0 0 0.5em;
+}
+
+.dokum-document h2 {
+  font-size: 1.3em;
+  font-weight: 700;
+  color: var(--brand, #00338d);
+  margin: 1em 0 0.4em;
+}
+
+.dokum-document p {
+  margin: 0.8em 0;
+}
+
+.dokum-document ul {
+  list-style: disc;
+  margin: 0.8em 0;
+  padding-left: 1.6em;
+}
+
+.dokum-document ol {
+  list-style: decimal;
+  margin: 0.8em 0;
+  padding-left: 1.6em;
+}
+
+.dokum-document pre {
+  background: #f1f4f8;
+  border: 1px solid #d7dce2;
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin: 0.8em 0;
+  font-family: Consolas, monospace;
+  font-size: 0.85em;
+  overflow-x: auto;
+}
+
+/* The hidden field masters the resolver reads — never shown. */
+.dokum-document #hiddenFields {
+  display: none;
+}
+
+/* ---------------------------------------------------- formula/image blocks */
+
+.dokum-document .formula-block,
+.dokum-document .image-block {
+  margin: 1em 0;
+  padding: 14px 16px;
+  border-left: 4px solid var(--brand, #00338d);
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fbfdff, #f5f8fc);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.06);
+}
+
+/* A dense derivation must not widen the page on a phone — it scrolls itself. */
+.dokum-document .render-target {
+  overflow-x: auto;
+  overflow-y: hidden;
+  text-align: center;
+}
+
+.dokum-document .render-target svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.dokum-document .image-block {
+  text-align: center;
+}
+
+.dokum-document .image-block img {
+  display: inline-block;
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+.dokum-document .block-caption {
+  margin-top: 10px;
+  font-size: 0.9em;
+  color: #374151;
+  text-align: left;
+}
+
+/* A formula MathJax could not typeset keeps its source visible rather than
+   collapsing to nothing — the document is still readable around it. */
+.dokum-document .formula-error {
+  color: #991b1b;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-family: Consolas, monospace;
+  font-size: 0.8em;
+  white-space: pre-wrap;
+  text-align: left;
+}
+
+/* ------------------------------------------------------ input/output pills */
+
+.dokum-document .input-field,
+.dokum-document .output-field {
+  display: inline-block;
+  padding: 1px 7px;
+  margin: 0 2px;
+  border-radius: 999px;
+  font-weight: 500;
+  font-size: 0.92em;
+  /* Read-only in this ticket — the editable control arrives with #68. */
+  user-select: text;
+}
+
+.dokum-document .input-field {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fbbf24;
+}
+
+.dokum-document .input-field.is-ref {
+  border-style: dashed;
+}
+
+.dokum-document .output-field {
+  background: #dbeafe;
+  color: #1e40af;
+  border: 1px solid #60a5fa;
+}
+
+.dokum-document .output-field.is-error {
+  background: #fee2e2;
+  color: #991b1b;
+  border-color: #fca5a5;
+}
+
+@media (max-width: 640px) {
+  .dokum-document {
+    font-size: 16px;
+  }
+
+  .dokum-document .formula-block,
+  .dokum-document .image-block {
+    padding: 12px;
+    border-radius: 10px;
+  }
+}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -157,11 +157,23 @@ export async function getUnitById(
 }
 
 // Returns Unit with fully sorted Tasks → Documents → DocumentImages. Used by public Unit detail page.
+//
+// The document columns are listed EXPLICITLY rather than `documents(*)` (#65).
+// `documents` gained a `content` JSONB column holding the full published
+// snapshot, and `*` would ship every document's JSON to this page on every
+// load. Listing the columns makes including `content` a deliberate decision
+// instead of an accident — the DAL being the only read path means this
+// discipline lives in exactly one place.
 export async function getUnitWithTasks(unitId: string): Promise<UnitWithTasks | null> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from('units')
-    .select('*, tasks(*, documents(*, document_images(id, file_path, position, created_at)))')
+    .select(
+      `*, tasks(*, documents(
+        id, task_id, title, description, file_path, file_type, position, created_at,
+        document_images(id, file_path, position, created_at)
+      ))`
+    )
     .eq('id', unitId)
     .single()
   if (error || !data) return null

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -164,13 +164,20 @@ export async function getUnitById(
 // load. Listing the columns makes including `content` a deliberate decision
 // instead of an accident — the DAL being the only read path means this
 // discipline lives in exactly one place.
+//
+// `content` IS included here, deliberately (#67): this page renders published
+// interactive documents live, so the snapshot is the thing being displayed,
+// not dead weight. The cost is real — every interactive document in the Unit
+// ships on load — and it is the reason the addressable per-document route
+// (#69) exists. Any query that does NOT render the document must leave the
+// column out.
 export async function getUnitWithTasks(unitId: string): Promise<UnitWithTasks | null> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from('units')
     .select(
       `*, tasks(*, documents(
-        id, task_id, title, description, file_path, file_type, position, created_at,
+        id, task_id, title, description, file_path, file_type, position, created_at, content,
         document_images(id, file_path, position, created_at)
       ))`
     )

--- a/src/lib/editor/controller.ts
+++ b/src/lib/editor/controller.ts
@@ -77,14 +77,13 @@ import {
   type LineToken,
 } from './field-resolver'
 import {
-  DocumentJsonSchema,
   JSON_IMPORT_EXAMPLE,
   createImageRemoveButton,
-  describeDocumentJsonError,
   importEditorJson,
   serializeEditorState,
-  type EditorDocumentJson,
+  type LatestEditorDocumentJson,
 } from './document-json'
+import { readDocumentJson } from './document-version'
 import { cleanupLatex } from './latex-display'
 import { librarySyncAction, shouldAddToLibrary } from './library-sync'
 import { loadMathJax } from './mathjax-loader'
@@ -178,13 +177,13 @@ export interface EditorController {
    * Serialises the live document (blocks, field state, formula library) to
    * versioned JSON — the draft-save payload (slice 7, #35).
    */
-  exportDocument(): EditorDocumentJson
+  exportDocument(): LatestEditorDocumentJson
   /**
    * Replaces the editor content and the formula library with a saved
    * document (draft load, slice 7). Resolves once every formula is
    * MathJax-rendered and the field state is refreshed.
    */
-  loadDocument(doc: EditorDocumentJson): Promise<void>
+  loadDocument(doc: LatestEditorDocumentJson): Promise<void>
   /**
    * „Add JSON"-Toolbar-Button (slice 9, #37): öffnet das JSON-Import-Modal
    * (Textarea, „Beispiel laden", Ersetzen/Anhängen-Checkbox). Import läuft
@@ -1621,7 +1620,7 @@ export function createEditorController(
 
   // --- Draft persistence (slice 7, #35) + JSON import (slice 9, #37) ---
 
-  function exportDocument(): EditorDocumentJson {
+  function exportDocument(): LatestEditorDocumentJson {
     return serializeEditorState(
       editor,
       libraryItems().map((it) => it.dataset['latex'] ?? '')
@@ -1653,7 +1652,7 @@ export function createEditorController(
   // The importer validates variable names BEFORE any DOM mutation, so a
   // throw here leaves the editor untouched.
   async function importDocument(
-    doc: EditorDocumentJson,
+    doc: LatestEditorDocumentJson,
     options: { replaceExisting: boolean }
   ): Promise<void> {
     const result = importEditorJson(
@@ -1677,7 +1676,7 @@ export function createEditorController(
     await reRenderAllLatexFormulas()
   }
 
-  async function loadDocument(doc: EditorDocumentJson): Promise<void> {
+  async function loadDocument(doc: LatestEditorDocumentJson): Promise<void> {
     return importDocument(doc, { replaceExisting: true })
   }
 
@@ -1716,15 +1715,16 @@ export function createEditorController(
       window.alert('JSON Import fehlgeschlagen:\nUngültiges JSON: ' + errorMessage(err))
       return
     }
-    const parsed = DocumentJsonSchema.safeParse(parsedJson)
-    if (!parsed.success) {
-      window.alert(
-        'JSON Import fehlgeschlagen:\n' + describeDocumentJsonError(parsed.error, parsedJson)
-      )
+    // Upgrade-on-read (#64): pasted JSON may carry any supported version, and
+    // the importer only ever sees the newest one. An unreadable snapshot is
+    // refused whole — never partially imported.
+    const parsed = readDocumentJson(parsedJson)
+    if (!parsed.ok) {
+      window.alert('JSON Import fehlgeschlagen:\n' + parsed.error)
       return
     }
     try {
-      await importDocument(parsed.data, { replaceExisting: jsonReplaceExisting.checked })
+      await importDocument(parsed.doc, { replaceExisting: jsonReplaceExisting.checked })
     } catch (err) {
       // Duplicate/colliding variable names — thrown before any DOM mutation
       // (German messages from the importer).

--- a/src/lib/editor/document-json.test.ts
+++ b/src/lib/editor/document-json.test.ts
@@ -18,6 +18,7 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  DOCUMENT_JSON_VERSIONS,
   DocumentJsonSchema,
   JSON_IMPORT_EXAMPLE,
   collectReferencedImageIds,
@@ -214,6 +215,48 @@ describe('DocumentJsonSchema', () => {
       library: ['a+b'],
     }
     expect(DocumentJsonSchema.safeParse(doc).success).toBe(true)
+  })
+})
+
+// ── Versioned family (#64) ──────────────────────────────────────────────────
+
+describe('DocumentJsonSchema — versioned family', () => {
+  it('discriminates on version: every supported version parses its own shape', () => {
+    for (const version of DOCUMENT_JSON_VERSIONS) {
+      const result = DocumentJsonSchema.safeParse({ version, variables: [], content: [] })
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data.version).toBe(version)
+    }
+  })
+
+  it('reports an unsupported version on the version path, not as a shape failure', () => {
+    // What keeps the German boundary message addressable — describeDocumentJsonError
+    // branches on path[0] === 'version'.
+    const result = DocumentJsonSchema.safeParse({ ...REFERENCE_EXAMPLE, version: '0.9' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path[0] === 'version')).toBe(true)
+    }
+  })
+
+  it('names every supported version in the unsupported-version message', () => {
+    const result = DocumentJsonSchema.safeParse({ ...REFERENCE_EXAMPLE, version: '0.9' })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    const message = describeDocumentJsonError(result.error, { ...REFERENCE_EXAMPLE, version: '0.9' })
+    for (const version of DOCUMENT_JSON_VERSIONS) expect(message).toContain(`"${version}"`)
+  })
+
+  it('keeps per-version strictness: a valid version does not relax unknown keys', () => {
+    for (const version of DOCUMENT_JSON_VERSIONS) {
+      const result = DocumentJsonSchema.safeParse({
+        version,
+        variables: [],
+        content: [],
+        schmuggelware: true,
+      })
+      expect(result.success).toBe(false)
+    }
   })
 })
 

--- a/src/lib/editor/document-json.ts
+++ b/src/lib/editor/document-json.ts
@@ -4,9 +4,12 @@
  *
  * Three parts:
  *
- * 1. `DocumentJsonSchema` — the versioned Zod schema (version "1.0"). It
- *    doubles as the server-action validation for draft saves (operator story
- *    34: malformed content is rejected at the boundary). The schema is a
+ * 1. `DocumentJsonSchema` — the versioned Zod schema: a DISCRIMINATED UNION
+ *    over `version` (#64), currently the single member v1.0. It doubles as
+ *    the server-action validation for draft saves (operator story
+ *    34: malformed content is rejected at the boundary). Reading a stored
+ *    snapshot goes through `readDocumentJson` (document-version.ts), which
+ *    parses here and then migrates to the newest version. The schema is a
  *    SUPERSET of the standalone editor's import format (reference file
  *    latexEditor/latex_editor_FIXED_JSON_IMPORT_COMPLETE_OUTPUT_AS_INPUT_LATEX_FIX.htm.html,
  *    `JSON_IMPORT_EXAMPLE` L2310): the reference example validates verbatim.
@@ -223,7 +226,36 @@ const VariableSchema = z.strictObject({
   sourceOutputName: z.string().optional(),
 })
 
-export const DocumentJsonSchema = z.strictObject({
+// ── Versioned family (#64) ──────────────────────────────────────────────────
+
+/**
+ * Every document-JSON version this build can read, OLDEST FIRST; the last
+ * entry is the version the serializer emits. `version` is a discriminated
+ * union rather than a literal so a new node type can ship without either
+ * rejecting every stored snapshot or rewriting them all in place — the
+ * prefactor the linking and video work sit on.
+ *
+ * Adding a version means all four of: append it here, add its
+ * `DocumentJsonV<n>Schema` to the union below, point
+ * `LATEST_DOCUMENT_JSON_VERSION` at it, and add the vN→vN+1 step in
+ * document-version.ts. The upgrade chain is a total record over this list, so
+ * a half-done addition fails to compile.
+ */
+export const DOCUMENT_JSON_VERSIONS = ['1.0'] as const
+
+export type DocumentJsonVersion = (typeof DOCUMENT_JSON_VERSIONS)[number]
+
+/** The version `serializeEditorState` emits and the renderer understands. */
+export const LATEST_DOCUMENT_JSON_VERSION = '1.0' satisfies DocumentJsonVersion
+
+/** German enumeration of the supported versions — `"1.0"`, `"1.0" oder "1.1"`, … */
+function supportedVersionList(): string {
+  const quoted = DOCUMENT_JSON_VERSIONS.map((v) => `"${v}"`)
+  if (quoted.length === 1) return quoted[0]
+  return quoted.slice(0, -1).join(', ') + ' oder ' + quoted[quoted.length - 1]
+}
+
+const DocumentJsonV1_0Schema = z.strictObject({
   version: z.literal('1.0'),
   /**
    * Save-time metadata. `term` is the ExportBar's free Term field (slice 10,
@@ -265,7 +297,23 @@ export const DocumentJsonSchema = z.strictObject({
   library: z.array(z.string()).optional(),
 })
 
+/**
+ * The versioned family. A snapshot whose `version` is not in
+ * {@link DOCUMENT_JSON_VERSIONS} fails on the `version` path — which is what
+ * lets {@link describeDocumentJsonError} refuse it with a clear German
+ * message instead of letting it fail as an unreadable shape mismatch.
+ */
+export const DocumentJsonSchema = z.discriminatedUnion('version', [DocumentJsonV1_0Schema])
+
+/** A snapshot at ANY version this build can read — what the schema parses. */
 export type EditorDocumentJson = z.infer<typeof DocumentJsonSchema>
+/**
+ * A snapshot at the NEWEST version — what `serializeEditorState` emits and
+ * what the importer and the student renderer consume. Older snapshots reach
+ * this type through `upgradeDocumentJson` (document-version.ts), never by
+ * being passed straight through.
+ */
+export type LatestEditorDocumentJson = z.infer<typeof DocumentJsonV1_0Schema>
 export type EditorDocumentVariable = z.infer<typeof VariableSchema>
 export type EditorDocumentBlock = z.infer<typeof BlockSchema>
 
@@ -309,7 +357,7 @@ export const JSON_IMPORT_EXAMPLE = {
       children: [{ text: 'Result: ', style: { bold: true } }, { field: 'EBIT' }],
     },
   ],
-} satisfies EditorDocumentJson
+} satisfies LatestEditorDocumentJson
 
 /** `content[2].children[0]`-style dot/bracket path of a Zod issue. */
 function formatIssuePath(path: ReadonlyArray<PropertyKey>): string {
@@ -331,7 +379,9 @@ function mostSpecificIssue(issues: z.ZodIssue[]): z.ZodIssue | undefined {
 
 /**
  * German error message for a failed `DocumentJsonSchema` parse — shown by the
- * JSON import modal. Pragmatic per the slice-9 decisions: German lead-in plus
+ * JSON import modal, and the refusal text of the read boundary
+ * (`readDocumentJson`, document-version.ts). Pragmatic per the slice-9
+ * decisions: German lead-in plus
  * special-cased common failures (root shape, schema version, reference-style
  * image blocks with embedded `src` — the whole import fails for those by
  * design, base64 must stay structurally impossible). Other Zod detail
@@ -346,12 +396,16 @@ export function describeDocumentJsonError(error: z.ZodError, raw: unknown): stri
     return 'Das JSON muss ein Objekt mit { version, variables, content } sein.'
   }
 
+  // The version label enumerates DOCUMENT_JSON_VERSIONS rather than naming
+  // 1.0, so the boundary keeps telling the truth as versions are added.
+  const formatLabel = `Version ${DOCUMENT_JSON_VERSIONS.join('/')}`
+
   const issue = mostSpecificIssue(error.issues)
-  if (!issue) return 'Das JSON entspricht nicht dem Dokumentformat (Version 1.0).'
+  if (!issue) return `Das JSON entspricht nicht dem Dokumentformat (${formatLabel}).`
 
   const path = issue.path
   if (path[0] === 'version') {
-    return 'Nicht unterstützte Schema-Version — erwartet wird "1.0".'
+    return `Nicht unterstützte Schema-Version — erwartet wird ${supportedVersionList()}.`
   }
   if (path[0] === 'content' && typeof path[1] === 'number') {
     const content = (raw as Record<string, unknown>)['content']
@@ -380,7 +434,7 @@ export function describeDocumentJsonError(error: z.ZodError, raw: unknown): stri
         ? 'Kein gültiger Block-/Inline-Knoten an dieser Stelle.'
         : issue.message
   const where = path.length ? formatIssuePath(path) : 'Dokument'
-  return `Das JSON entspricht nicht dem Dokumentformat (Version 1.0) — ${where}: ${detail}`
+  return `Das JSON entspricht nicht dem Dokumentformat (${formatLabel}) — ${where}: ${detail}`
 }
 
 // ── Shared helpers (reference L2388–2390) ───────────────────────────────────
@@ -736,7 +790,7 @@ function createBlock(
  * {@link ImportResult}.
  */
 export function importEditorJson(
-  doc: EditorDocumentJson,
+  doc: LatestEditorDocumentJson,
   editor: HTMLElement,
   adapters: ImportAdapters,
   options?: { replaceExisting?: boolean }
@@ -1004,7 +1058,10 @@ function variableFromElement(el: HTMLElement, id: string): EditorDocumentVariabl
  * LaTeX list (the controller reads it from the sidebar items; the library
  * lives outside the editor element).
  */
-export function serializeEditorState(editor: HTMLElement, library: string[]): EditorDocumentJson {
+export function serializeEditorState(
+  editor: HTMLElement,
+  library: string[]
+): LatestEditorDocumentJson {
   const content: EditorDocumentBlock[] = []
   let pendingInline: InlineNode[] = []
 
@@ -1046,7 +1103,7 @@ export function serializeEditorState(editor: HTMLElement, library: string[]): Ed
   flushInline()
 
   return {
-    version: '1.0',
+    version: LATEST_DOCUMENT_JSON_VERSION,
     variables: serializeVariables(editor),
     content,
     library: [...library],
@@ -1077,8 +1134,8 @@ export function collectReferencedImageIds(doc: EditorDocumentJson): string[] {
  * draft that `uploadEditorImage` creates when an image is inserted before the
  * first save (an anchor row only, never content autosave).
  */
-export function emptyEditorDocumentJson(): EditorDocumentJson {
-  return { version: '1.0', variables: [], content: [], library: [] }
+export function emptyEditorDocumentJson(): LatestEditorDocumentJson {
+  return { version: LATEST_DOCUMENT_JSON_VERSION, variables: [], content: [], library: [] }
 }
 
 /**
@@ -1090,7 +1147,10 @@ export function emptyEditorDocumentJson(): EditorDocumentJson {
  * stringifying the save payload. A blank term returns the document unchanged
  * (no empty `meta` object is ever emitted).
  */
-export function withDocumentMeta(doc: EditorDocumentJson, term: string): EditorDocumentJson {
+export function withDocumentMeta(
+  doc: LatestEditorDocumentJson,
+  term: string
+): LatestEditorDocumentJson {
   const trimmed = term.trim()
   if (!trimmed) return doc
   return { ...doc, meta: { term: trimmed } }

--- a/src/lib/editor/document-render.test.ts
+++ b/src/lib/editor/document-render.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+/**
+ * document-render tests (#67).
+ *
+ * Behavioural: given a published snapshot, what does the STUDENT get? Not
+ * which helper ran, not the internal call order — what is on screen, what is
+ * selectable, what is resolved, and what editor affordances are provably
+ * absent.
+ *
+ * Runs in jsdom, in the style of the document-json suite: the renderer builds
+ * real DOM and stays MathJax-free, so the formula assertions check the
+ * resolved LaTeX handed to MathJax rather than its SVG output.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { LatestEditorDocumentJson } from './document-json'
+import { renderDocumentJson } from './document-render'
+
+const IMG_ID = '44444444-4444-4444-8444-444444444444'
+
+function mount(): HTMLElement {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  return host
+}
+
+function render(doc: LatestEditorDocumentJson, host = mount()) {
+  const result = renderDocumentJson(doc, host, { imageUrl: (id) => `/api/image/${id}` })
+  return { host, result }
+}
+
+/** A document exercising every v1.0 block type plus the field graph. */
+const DOC: LatestEditorDocumentJson = {
+  version: '1.0',
+  variables: [
+    { id: 'v_rev', type: 'input', name: 'Revenue', refType: 'static', value: 1200 },
+    { id: 'v_mar', type: 'input', name: 'Margin', refType: 'static', value: 0.2534 },
+    { id: 'v_ebit', type: 'output', name: 'EBIT', expr: 'Revenue * Margin' },
+  ],
+  content: [
+    { type: 'heading', level: 1, children: [{ text: 'Bewertung' }] },
+    {
+      type: 'paragraph',
+      children: [{ text: 'Umsatz: ' }, { fieldId: 'v_rev' }, { text: ' | Marge: ' }, { fieldId: 'v_mar' }],
+    },
+    { type: 'formula', latex: 'EBIT = [input:Revenue] \\cdot [input:Margin]' },
+    { type: 'paragraph', children: [{ text: 'Ergebnis: ' }, { fieldId: 'v_ebit' }] },
+    { type: 'list', ordered: false, items: [[{ text: 'Punkt A' }], [{ text: 'Punkt B' }]] },
+    { type: 'code', text: 'x^2' },
+    { type: 'image', imageId: IMG_ID, alt: 'Diagramm' },
+  ],
+  library: [],
+}
+
+// ── Content renders as real content ─────────────────────────────────────────
+
+describe('renderDocumentJson — structure', () => {
+  it('renders each block type as its own element', () => {
+    const { host } = render(DOC)
+    expect(host.querySelector('h1')?.textContent).toBe('Bewertung')
+    expect(host.querySelectorAll('p').length).toBe(2)
+    expect(host.querySelectorAll('ul li').length).toBe(2)
+    expect(host.querySelector('pre')?.textContent).toBe('x^2')
+    expect(host.querySelector('.formula-block')).not.toBeNull()
+    expect(host.querySelector('.image-block')).not.toBeNull()
+  })
+
+  it('produces real selectable text, not an image of text', () => {
+    const { host } = render(DOC)
+    // The words a student would want to copy are present as text nodes.
+    expect(host.textContent).toContain('Bewertung')
+    expect(host.textContent).toContain('Umsatz:')
+    expect(host.textContent).toContain('Punkt A')
+    expect(host.querySelectorAll('img[data-image-id]').length).toBe(1)
+  })
+
+  it('resolves images through the injected entitlement-gated route', () => {
+    const { host } = render(DOC)
+    const img = host.querySelector<HTMLImageElement>('img[data-image-id]')
+    expect(img?.getAttribute('src')).toBe(`/api/image/${IMG_ID}`)
+    expect(img?.getAttribute('alt')).toBe('Diagramm')
+  })
+
+  it('replaces previous content when the same container is rendered again', () => {
+    const { host } = render(DOC)
+    render(DOC, host)
+    expect(host.querySelectorAll('h1').length).toBe(1)
+    expect(host.querySelectorAll('.image-block').length).toBe(1)
+  })
+})
+
+// ── No editor affordances reach the student ─────────────────────────────────
+
+describe('renderDocumentJson — editor chrome is stripped', () => {
+  it('carries no drag handles, delete buttons or draggable blocks', () => {
+    const { host } = render(DOC)
+    expect(host.querySelector('.drag-handle')).toBeNull()
+    expect(host.querySelector('.img-remove')).toBeNull()
+    expect(host.querySelector('[draggable]')).toBeNull()
+  })
+
+  it('leaves nothing contenteditable — the document text is fixed', () => {
+    const doc: LatestEditorDocumentJson = {
+      ...DOC,
+      content: [{ type: 'formula', latex: 'a+b', caption: 'Eine Bildunterschrift' }],
+    }
+    const { host } = render(doc)
+    expect(host.querySelector('[contenteditable]')).toBeNull()
+    // The caption still renders — only its editability is gone.
+    expect(host.textContent).toContain('Eine Bildunterschrift')
+  })
+})
+
+// ── Computed values ─────────────────────────────────────────────────────────
+
+describe('renderDocumentJson — field values', () => {
+  it('shows a static input’s own value', () => {
+    const { host } = render(DOC)
+    const rev = host.querySelector('.input-field[data-field-id="v_rev"]')
+    expect(rev?.textContent).toBe('1200')
+  })
+
+  it('shows an output’s computed value, German-formatted', () => {
+    const { host } = render(DOC)
+    const ebit = host.querySelector('.output-field[data-field-id="v_ebit"]')
+    expect(ebit?.textContent).toBe('304,08')
+  })
+
+  it('marks a non-resolvable output as an error rather than blank', () => {
+    const doc: LatestEditorDocumentJson = {
+      version: '1.0',
+      variables: [{ id: 'v_bad', type: 'output', name: 'Kaputt', expr: 'Unbekannt * 2' }],
+      content: [{ type: 'paragraph', children: [{ fieldId: 'v_bad' }] }],
+      library: [],
+    }
+    const { host } = render(doc)
+    const field = host.querySelector('.output-field[data-field-id="v_bad"]')
+    expect(field?.textContent).toBe('Err')
+    expect(field?.classList.contains('is-error')).toBe(true)
+  })
+
+  it('resolves a reference input to the value it points at', () => {
+    const doc: LatestEditorDocumentJson = {
+      version: '1.0',
+      variables: [
+        { id: 'v_a', type: 'input', name: 'A', refType: 'static', value: 2500 },
+        { id: 'v_out', type: 'output', name: 'Doppelt', expr: 'A * 2' },
+        { id: 'v_clone', type: 'input', refType: 'ref', refId: 'v_out', referenceClone: true },
+      ],
+      content: [{ type: 'paragraph', children: [{ fieldId: 'v_clone' }] }],
+      library: [],
+    }
+    const { host } = render(doc)
+    expect(host.querySelector('.input-field[data-field-id="v_clone"]')?.textContent).toBe('5 000')
+  })
+})
+
+// ── Formulas ────────────────────────────────────────────────────────────────
+
+describe('renderDocumentJson — formulas', () => {
+  it('returns a render target per formula, in document order', () => {
+    const doc: LatestEditorDocumentJson = {
+      version: '1.0',
+      variables: [],
+      content: [
+        { type: 'formula', latex: 'a+b' },
+        { type: 'paragraph', children: [{ text: 'dazwischen' }] },
+        { type: 'formula', latex: 'c+d' },
+      ],
+      library: [],
+    }
+    const { result } = render(doc)
+    expect(result.renderTargets.map((t) => t.dataset['rawLatex'])).toEqual(['a+b', 'c+d'])
+  })
+
+  it('hands MathJax the RESOLVED latex and keeps the raw source alongside', () => {
+    const { result } = render(DOC)
+    const target = result.renderTargets[0]
+    expect(target?.dataset['rawLatex']).toBe('EBIT = [input:Revenue] \\cdot [input:Margin]')
+    // Placeholders become German-formatted display values (reference parity).
+    expect(target?.dataset['latex']).toContain('1 200')
+    expect(target?.dataset['latex']).toContain('0,2534')
+    expect(target?.dataset['latex']).not.toContain('[input:')
+  })
+
+  it('leaves an unknown placeholder name visible rather than silently blank', () => {
+    const doc: LatestEditorDocumentJson = {
+      version: '1.0',
+      variables: [],
+      content: [{ type: 'formula', latex: 'x = [input:GibtEsNicht]' }],
+      library: [],
+    }
+    const { result } = render(doc)
+    expect(result.renderTargets[0]?.dataset['latex']).toContain('[input:GibtEsNicht]')
+  })
+})
+
+// ── Purity ──────────────────────────────────────────────────────────────────
+
+describe('renderDocumentJson — purity', () => {
+  it('does not mutate the snapshot it renders', () => {
+    const before = JSON.stringify(DOC)
+    render(DOC)
+    expect(JSON.stringify(DOC)).toBe(before)
+  })
+
+  it('renders into the container it is given and nowhere else', () => {
+    const other = mount()
+    const { host } = render(DOC)
+    expect(host.childNodes.length).toBeGreaterThan(0)
+    expect(other.childNodes.length).toBe(0)
+  })
+})

--- a/src/lib/editor/document-render.ts
+++ b/src/lib/editor/document-render.ts
@@ -12,8 +12,17 @@
  * knows every v1.0 block and inline shape, including the field-pill clones and
  * reference resolution), the field resolver, the expression evaluator, the
  * LaTeX normaliser and the German number formatter — so the student sees the
- * same document the author built, resolved by the same code, with no second
- * implementation to keep in parity.
+ * same document the author built, resolved by the same code.
+ *
+ * ⚠ ONE THING IS DUPLICATED, KNOWINGLY: {@link domFieldGraph} mirrors the
+ * controller's DOM adapter (controller.ts, `fieldGraph`/`tokenizeLine`/
+ * `toFieldData`) almost line for line. The two roots differ — the controller
+ * owns a live contenteditable, this owns a read-only container — and folding
+ * them together means editing the shipped editor, whose behaviour is pinned
+ * by parity goldens. It was left duplicated deliberately, but it IS a second
+ * implementation: a change to either adapter must be mirrored in the other,
+ * or the editor and the student view will resolve the same document
+ * differently. Extracting the shared adapter is the right follow-up.
  *
  * Two deliberate properties:
  *

--- a/src/lib/editor/document-render.ts
+++ b/src/lib/editor/document-render.ts
@@ -1,0 +1,239 @@
+/**
+ * document-render — the student-facing renderer for published document JSON
+ * (#67, spec #63 §4).
+ *
+ * This is the payoff of not flattening documents to a picture: a published
+ * snapshot renders as live content — real selectable text, crisply typeset
+ * formulas, images, and computed values — instead of a PNG.
+ *
+ * It is Option B of the structure decision: a dedicated renderer that REUSES
+ * the editor's already-pure modules rather than mounting the imperative
+ * controller read-only. Concretely it reuses the JSON importer (which already
+ * knows every v1.0 block and inline shape, including the field-pill clones and
+ * reference resolution), the field resolver, the expression evaluator, the
+ * LaTeX normaliser and the German number formatter — so the student sees the
+ * same document the author built, resolved by the same code, with no second
+ * implementation to keep in parity.
+ *
+ * Two deliberate properties:
+ *
+ * 1. **MathJax-free, therefore jsdom-testable.** Like document-json.ts, this
+ *    module builds DOM and stops. The formula elements come back in
+ *    {@link DocumentRenderResult.renderTargets} carrying their RESOLVED LaTeX,
+ *    and the React layer typesets them with the bundled loader. No CDN, no
+ *    `eval`, no CSP change — the renderer needs none of it.
+ *
+ * 2. **Editor chrome never reaches the student.** The importer builds editor
+ *    DOM: drag handles, image delete buttons, `draggable` blocks and an
+ *    editable caption. All of it is stripped after the import, in one pass, so
+ *    the two paths cannot drift — a new affordance added to the importer is
+ *    removed here by class, not by having remembered to.
+ *
+ * The hidden field store the importer creates is KEPT (it is `display:none`):
+ * it holds the field masters the resolver reads, and it is what the
+ * student-editable inputs of #68 will recompute against.
+ *
+ * Pure module: no MathJax, no server imports, no mutation of the snapshot.
+ * DOM is created through the container's `ownerDocument`, so it runs in the
+ * browser and in jsdom alike.
+ */
+
+import { importEditorJson, type LatestEditorDocumentJson } from './document-json'
+import {
+  fieldDisplay,
+  resolveFieldPlaceholders,
+  type FieldData,
+  type FieldGraph,
+  type LineToken,
+} from './field-resolver'
+import { formatValue } from './number-format'
+
+export interface DocumentRenderAdapters {
+  /**
+   * Browser URL for a re-homed document image. The caller passes the
+   * entitlement-gated `/api/image/[imageId]` route — publishing rewrote the
+   * snapshot's ids to `document_images` rows (#66), so no new access path is
+   * needed.
+   */
+  imageUrl(imageId: string): string
+}
+
+export interface DocumentRenderResult {
+  /**
+   * The `.render-target` element of every formula, in document order, each
+   * carrying its resolved LaTeX in `data-latex` and its source in
+   * `data-raw-latex`. The caller MathJax-renders them.
+   */
+  renderTargets: HTMLElement[]
+}
+
+const FIELD_SELECTOR = '.input-field, .output-field'
+
+/**
+ * Renders a published snapshot into `container`, replacing whatever was there.
+ *
+ * Throws if the snapshot cannot be rendered — the caller is expected to catch
+ * that inside an error boundary and fall back to the stored PNG. Rendering
+ * something partial is not an option: silently dropping a node means a paying
+ * student misses a whole section with no indication.
+ */
+export function renderDocumentJson(
+  doc: LatestEditorDocumentJson,
+  container: HTMLElement,
+  adapters: DocumentRenderAdapters
+): DocumentRenderResult {
+  const graph = domFieldGraph(container)
+
+  let seq = 0
+  const { renderTargets } = importEditorJson(doc, container, {
+    nextFieldId: () => `sf_${++seq}`,
+    resolvePlaceholders: (raw) => resolveFieldPlaceholders(graph, raw),
+    imageUrl: adapters.imageUrl,
+  })
+
+  // Resolve in document order so a later formula sees an earlier one's
+  // `[output:x]` write-back, then refresh every pill from the settled graph —
+  // the same two-step the controller performs after an import.
+  for (const target of renderTargets) {
+    const raw = target.dataset['rawLatex'] ?? ''
+    if (!raw) continue
+    const resolved = resolveFieldPlaceholders(graph, raw)
+    target.dataset['latex'] = resolved
+    target.textContent = resolved
+  }
+  refreshFields(container, graph)
+
+  stripEditorChrome(container)
+
+  return { renderTargets }
+}
+
+/** Applies the resolved display state to every field pill in the container. */
+function refreshFields(container: HTMLElement, graph: FieldGraph): void {
+  for (const el of Array.from(container.querySelectorAll<HTMLElement>(FIELD_SELECTOR))) {
+    const id = el.dataset['fieldId'] ?? ''
+    if (!id) continue
+    const display = fieldDisplay(graph, id)
+    el.textContent = display.text
+    el.classList.toggle('is-error', display.isError)
+    el.classList.toggle('is-ref', display.isRef)
+  }
+}
+
+/**
+ * Removes everything the importer builds for the sake of EDITING. Selected by
+ * class and attribute rather than by block type, so an affordance added to the
+ * importer later is stripped here without a matching change.
+ */
+function stripEditorChrome(container: HTMLElement): void {
+  for (const el of Array.from(container.querySelectorAll('.drag-handle, .img-remove'))) {
+    el.remove()
+  }
+  for (const el of Array.from(container.querySelectorAll('[draggable]'))) {
+    el.removeAttribute('draggable')
+  }
+  // Captions are built `contenteditable="true"`; field pills carry
+  // `contenteditable="false"`. Neither means anything inside a container that
+  // is not editable, and leaving the "true" ones would let a student type into
+  // the material they are studying.
+  for (const el of Array.from(container.querySelectorAll('[contenteditable]'))) {
+    el.removeAttribute('contenteditable')
+  }
+}
+
+// ── Field graph over the rendered DOM ───────────────────────────────────────
+
+function fieldDataFrom(el: HTMLElement): FieldData {
+  const data: FieldData = {
+    id: el.dataset['fieldId'] ?? '',
+    type: el.dataset['type'] === 'output' ? 'output' : 'input',
+    name: el.dataset['name'] ?? '',
+  }
+  if (el.dataset['refType'] !== undefined) {
+    data.refType = el.dataset['refType'] === 'ref' ? 'ref' : 'static'
+  }
+  if (el.dataset['value'] !== undefined) data.value = el.dataset['value']
+  if (el.dataset['refId'] !== undefined) data.refId = el.dataset['refId']
+  if (el.dataset['expr'] !== undefined) data.expr = el.dataset['expr']
+  if (el.dataset['latexValue'] !== undefined) data.latexValue = el.dataset['latexValue']
+  return data
+}
+
+/** Top-level block of the container that contains `el`, or null. */
+function topLevelBlock(container: HTMLElement, el: HTMLElement): HTMLElement | null {
+  let node: HTMLElement | null = el
+  while (node && node.parentElement && node.parentElement !== container) {
+    node = node.parentElement
+  }
+  return node && node.parentElement === container ? node : null
+}
+
+/** Characters and field pills of a line, in document order (reference tokenizeLine). */
+function tokenizeLine(line: Node): LineToken[] {
+  const tokens: LineToken[] = []
+  function walk(node: Node): void {
+    if (node.nodeType === Node.TEXT_NODE) {
+      for (const ch of node.textContent ?? '') tokens.push({ char: ch })
+      return
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return
+    const el = node as HTMLElement
+    if (el.classList.contains('drag-handle')) return
+    if (el.classList.contains('input-field') || el.classList.contains('output-field')) {
+      tokens.push({ fieldId: el.dataset['fieldId'] ?? '' })
+      return
+    }
+    for (const child of Array.from(node.childNodes)) walk(child)
+  }
+  walk(line)
+  return tokens
+}
+
+/**
+ * The same thin DOM adapter the controller implements, over the rendered
+ * document. Sharing the shape is the point: the resolver sees plain objects
+ * and cannot tell the editor and the student view apart, so both resolve
+ * identically — including the `[output:x]` write-back, which must be visible
+ * to later reads within the same pass.
+ *
+ * Exported because the student-editable inputs of #68 recompute against it.
+ */
+export function domFieldGraph(container: HTMLElement): FieldGraph {
+  // Plain interpolation, as the controller does: the importer runs every id
+  // through `safeFieldId`, which leaves only [A-Za-z0-9_\-:.] — no quote can
+  // reach this selector. (CSS.escape is also absent in jsdom.)
+  const elementById = (id: string): HTMLElement | null =>
+    container.querySelector<HTMLElement>(`[data-field-id="${id}"]`)
+
+  return {
+    byId(id) {
+      const el = elementById(id)
+      return el ? fieldDataFrom(el) : null
+    },
+    all() {
+      return Array.from(container.querySelectorAll<HTMLElement>(FIELD_SELECTOR)).map(fieldDataFrom)
+    },
+    lineTokensFor(fieldId) {
+      const el = elementById(fieldId)
+      if (!el) return null
+      const line = topLevelBlock(container, el)
+      if (!line) return null
+      // Hidden masters have no text-line context (reference L1532).
+      if (line.id === 'hiddenFields') return null
+      return tokenizeLine(line)
+    },
+    setLatexValue(fieldId, v) {
+      const el = elementById(fieldId)
+      if (!el) return
+      if (Number.isFinite(v)) {
+        el.dataset['latexValue'] = String(v)
+        el.textContent = formatValue(v)
+        el.classList.remove('is-error')
+      } else {
+        delete el.dataset['latexValue']
+        el.textContent = 'Err'
+        el.classList.add('is-error')
+      }
+    },
+  }
+}

--- a/src/lib/editor/document-version.test.ts
+++ b/src/lib/editor/document-version.test.ts
@@ -1,0 +1,161 @@
+/**
+ * document-version tests (#64).
+ *
+ * Behavioural, not structural: given a stored snapshot, what does the read
+ * boundary hand the renderer? The load-bearing property is the REFUSAL —
+ * for paid material an honest failure beats quietly dropping a node the
+ * student paid for, so every "cannot understand this" path must return
+ * `ok: false` and never a partially populated document.
+ *
+ * Runs in plain Node: nothing here touches the DOM.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  DOCUMENT_JSON_VERSIONS,
+  LATEST_DOCUMENT_JSON_VERSION,
+  type DocumentJsonVersion,
+  type EditorDocumentJson,
+} from './document-json'
+import {
+  DOCUMENT_JSON_UPGRADES,
+  readDocumentJson,
+  upgradeDocumentJson,
+} from './document-version'
+
+/**
+ * One minimal valid document per supported version. Typed as a total record,
+ * so adding a version to DOCUMENT_JSON_VERSIONS fails to compile until its
+ * fixture exists — the chain tests below then cover it for free.
+ */
+const MINIMAL_BY_VERSION: Record<DocumentJsonVersion, EditorDocumentJson> = {
+  '1.0': { version: '1.0', variables: [], content: [] },
+}
+
+const V1_0 = {
+  version: '1.0',
+  variables: [{ id: 'v1', type: 'input', name: 'Revenue', refType: 'static', value: 1200 }],
+  content: [
+    { type: 'heading', level: 1, children: [{ text: 'Titel' }] },
+    { type: 'paragraph', children: [{ text: 'Umsatz: ' }, { fieldId: 'v1' }] },
+  ],
+  library: [],
+} satisfies EditorDocumentJson
+
+// ── The version list ────────────────────────────────────────────────────────
+
+describe('DOCUMENT_JSON_VERSIONS', () => {
+  it('is ordered oldest → newest, with LATEST as the last entry', () => {
+    expect(DOCUMENT_JSON_VERSIONS.length).toBeGreaterThan(0)
+    expect(DOCUMENT_JSON_VERSIONS[DOCUMENT_JSON_VERSIONS.length - 1]).toBe(
+      LATEST_DOCUMENT_JSON_VERSION
+    )
+  })
+
+  it('carries an upgrade step for every version — the chain is total', () => {
+    for (const version of DOCUMENT_JSON_VERSIONS) {
+      expect(typeof DOCUMENT_JSON_UPGRADES[version]).toBe('function')
+    }
+  })
+})
+
+// ── The upgrade chain ───────────────────────────────────────────────────────
+
+describe('upgradeDocumentJson', () => {
+  it('returns a latest-version document unchanged (the identity step)', () => {
+    const doc = MINIMAL_BY_VERSION[LATEST_DOCUMENT_JSON_VERSION]
+    expect(upgradeDocumentJson(doc)).toEqual(doc)
+  })
+
+  it('lifts every supported version to the latest version', () => {
+    for (const version of DOCUMENT_JSON_VERSIONS) {
+      const upgraded = upgradeDocumentJson(MINIMAL_BY_VERSION[version])
+      expect(upgraded.version).toBe(LATEST_DOCUMENT_JSON_VERSION)
+    }
+  })
+
+  it('is pure — the input document is not mutated', () => {
+    const before = JSON.stringify(V1_0)
+    upgradeDocumentJson(V1_0)
+    expect(JSON.stringify(V1_0)).toBe(before)
+  })
+
+  it('preserves the document body across the chain', () => {
+    const upgraded = upgradeDocumentJson(V1_0)
+    expect(upgraded.content).toEqual(V1_0.content)
+    expect(upgraded.variables).toEqual(V1_0.variables)
+  })
+
+  it('refuses a version outside the supported list rather than coercing it', () => {
+    // Only reachable through an unchecked cast — the schema rejects it first.
+    const alien = { version: '9.9', variables: [], content: [] } as unknown as EditorDocumentJson
+    expect(() => upgradeDocumentJson(alien)).toThrow(/Schema-Version/)
+  })
+})
+
+// ── The read boundary ───────────────────────────────────────────────────────
+
+describe('readDocumentJson', () => {
+  it('accepts a v1.0 snapshot and returns it at the latest version', () => {
+    const result = readDocumentJson(V1_0)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.doc.version).toBe(LATEST_DOCUMENT_JSON_VERSION)
+      expect(result.doc.content).toEqual(V1_0.content)
+    }
+  })
+
+  it('accepts a snapshot that arrived as a JSON round-trip (the DB read shape)', () => {
+    const result = readDocumentJson(JSON.parse(JSON.stringify(V1_0)))
+    expect(result.ok).toBe(true)
+  })
+
+  it('refuses an unrecognised version with the German boundary message', () => {
+    const result = readDocumentJson({ ...V1_0, version: '2.0' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBe('Nicht unterstützte Schema-Version — erwartet wird "1.0".')
+    }
+  })
+
+  it('refuses a missing version', () => {
+    const withoutVersion: Record<string, unknown> = { ...V1_0 }
+    delete withoutVersion['version']
+    expect(readDocumentJson(withoutVersion).ok).toBe(false)
+  })
+
+  it('refuses an unknown node type instead of dropping it', () => {
+    // The honest-failure rule: a student who paid for this document must not
+    // silently lose a block the renderer does not understand.
+    const result = readDocumentJson({
+      ...V1_0,
+      content: [...V1_0.content, { type: 'video', videoId: 'abc' }],
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('content[2]')
+  })
+
+  it('refuses unknown keys — strictness is unchanged', () => {
+    expect(readDocumentJson({ ...V1_0, extra: true }).ok).toBe(false)
+    expect(
+      readDocumentJson({
+        ...V1_0,
+        content: [{ type: 'code', text: 'x', bogus: true }],
+      }).ok
+    ).toBe(false)
+  })
+
+  it('refuses non-object snapshots, including null and undefined', () => {
+    for (const raw of [null, undefined, 42, 'kein objekt', [1, 2]]) {
+      const result = readDocumentJson(raw)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('never returns a partial document on failure', () => {
+    const result = readDocumentJson({ ...V1_0, content: [{ type: 'nope' }] })
+    expect(result.ok).toBe(false)
+    expect('doc' in result).toBe(false)
+  })
+})

--- a/src/lib/editor/document-version.test.ts
+++ b/src/lib/editor/document-version.test.ts
@@ -21,6 +21,7 @@ import {
   DOCUMENT_JSON_UPGRADES,
   readDocumentJson,
   upgradeDocumentJson,
+  upgradeThroughChain,
 } from './document-version'
 
 /**
@@ -90,6 +91,80 @@ describe('upgradeDocumentJson', () => {
     // Only reachable through an unchecked cast — the schema rejects it first.
     const alien = { version: '9.9', variables: [], content: [] } as unknown as EditorDocumentJson
     expect(() => upgradeDocumentJson(alien)).toThrow(/Schema-Version/)
+  })
+
+  it('runs the identity step rather than short-circuiting past it', () => {
+    // The identity step is what terminates the walk, so a missing step can
+    // never be mistaken for "already newest".
+    let identityRuns = 0
+    const result = upgradeThroughChain(
+      { version: '1.0', marker: 'unverändert' },
+      { '1.0': (doc) => { identityRuns++; return doc } },
+      '1.0'
+    )
+    expect(identityRuns).toBe(1)
+    expect(result.marker).toBe('unverändert')
+  })
+})
+
+// ── The ladder itself, across real version hops ─────────────────────────────
+//
+// Only v1.0 exists in production, so the multi-version behaviour is exercised
+// against a synthetic ladder. This is what makes the chain a chain rather than
+// an assertion about a single entry — when v1.1 lands, these are the semantics
+// it inherits.
+
+describe('upgradeThroughChain', () => {
+  interface Fixture {
+    version: string
+    steps: string[]
+  }
+
+  const LADDER: Record<string, ((doc: Fixture) => Fixture) | undefined> = {
+    '0.8': (doc) => ({ version: '0.9', steps: [...doc.steps, '0.8→0.9'] }),
+    '0.9': (doc) => ({ version: '1.0', steps: [...doc.steps, '0.9→1.0'] }),
+    '1.0': (doc) => doc,
+  }
+
+  it('climbs every rung in order, oldest to newest', () => {
+    const result = upgradeThroughChain({ version: '0.8', steps: [] }, LADDER, '1.0')
+    expect(result.version).toBe('1.0')
+    expect(result.steps).toEqual(['0.8→0.9', '0.9→1.0'])
+  })
+
+  it('starts from whatever version the snapshot carries', () => {
+    const result = upgradeThroughChain({ version: '0.9', steps: [] }, LADDER, '1.0')
+    expect(result.steps).toEqual(['0.9→1.0'])
+  })
+
+  it('leaves the caller’s document alone — each rung returns a new value', () => {
+    const original = { version: '0.8', steps: [] }
+    upgradeThroughChain(original, LADDER, '1.0')
+    expect(original).toEqual({ version: '0.8', steps: [] })
+  })
+
+  it('refuses a version with no rung', () => {
+    expect(() => upgradeThroughChain({ version: '0.5', steps: [] }, LADDER, '1.0')).toThrow(
+      /Nicht unterstützte Schema-Version/
+    )
+  })
+
+  it('refuses a rung below the top that fails to advance, instead of looping', () => {
+    const broken: Record<string, ((doc: Fixture) => Fixture) | undefined> = {
+      '0.9': (doc) => doc, // claims to upgrade, does not
+      '1.0': (doc) => doc,
+    }
+    expect(() => upgradeThroughChain({ version: '0.9', steps: [] }, broken, '1.0')).toThrow(
+      /hat die Version nicht erhöht/
+    )
+  })
+
+  it('refuses a ladder that never reaches the top', () => {
+    const cyclic: Record<string, ((doc: Fixture) => Fixture) | undefined> = {
+      '0.8': (doc) => ({ ...doc, version: '0.9' }),
+      '0.9': (doc) => ({ ...doc, version: '0.8' }),
+    }
+    expect(() => upgradeThroughChain({ version: '0.8', steps: [] }, cyclic, '1.0')).toThrow()
   })
 })
 

--- a/src/lib/editor/document-version.ts
+++ b/src/lib/editor/document-version.ts
@@ -1,0 +1,121 @@
+/**
+ * document-version — upgrade-on-read for the versioned document JSON (#64).
+ *
+ * The document schema is a discriminated union over `version`
+ * (document-json.ts). This module is the other half: a pure vN→vN+1 chain
+ * that lifts a stored snapshot from whatever version it carries to the newest
+ * version this build understands, and `readDocumentJson`, the single boundary
+ * every stored snapshot passes through.
+ *
+ * Two rules make this module worth its own seam:
+ *
+ * 1. **Honest failure.** A snapshot whose version is unrecognised, or whose
+ *    upgrade throws, is REFUSED — never partially accepted, never silently
+ *    coerced. For paid material, dropping a node the student paid for with no
+ *    indication is worse than failing loudly: the caller can fall back to the
+ *    stored PNG, which it cannot do if it was handed a document that merely
+ *    looks complete. `readDocumentJson` therefore returns a result union with
+ *    no `doc` on the failure branch, rather than throwing or repairing.
+ *
+ * 2. **Purity.** Every step is a plain value→value function: no DOM, no
+ *    MathJax, no server imports, no mutation of its input. That is what makes
+ *    the chain unit-testable and what lets it run identically in the editor,
+ *    in a server action and in the student renderer.
+ *
+ * Adding a version: append it to `DOCUMENT_JSON_VERSIONS`, add its schema to
+ * the union, move `LATEST_DOCUMENT_JSON_VERSION`, then add its step below.
+ * `DOCUMENT_JSON_UPGRADES` is a TOTAL record over the version list, so the
+ * compiler refuses a half-done addition — the newest version keeps the
+ * identity step, every older one returns the next version's shape.
+ */
+
+import {
+  DOCUMENT_JSON_VERSIONS,
+  DocumentJsonSchema,
+  LATEST_DOCUMENT_JSON_VERSION,
+  describeDocumentJsonError,
+  type DocumentJsonVersion,
+  type EditorDocumentJson,
+  type LatestEditorDocumentJson,
+} from './document-json'
+
+/** One rung of the ladder: a snapshot at version N → the same document at N+1. */
+type UpgradeStep = (doc: EditorDocumentJson) => EditorDocumentJson
+
+/**
+ * The vN→vN+1 chain, keyed by the version being upgraded FROM. Total over
+ * {@link DOCUMENT_JSON_VERSIONS}: the newest version maps to identity (there
+ * is nothing above it), every older version returns the next version's shape.
+ *
+ * Steps must be pure and must not mutate their input — `upgradeDocumentJson`
+ * relies on that to keep the caller's document intact.
+ */
+export const DOCUMENT_JSON_UPGRADES: Record<DocumentJsonVersion, UpgradeStep> = {
+  /** Identity — 1.0 is the newest version this build understands. */
+  '1.0': (doc) => doc,
+}
+
+/**
+ * Migrates a schema-valid snapshot up to {@link LATEST_DOCUMENT_JSON_VERSION}.
+ *
+ * Throws a German `Error` when the version is outside the supported list, or
+ * when a step fails to advance the version (a malformed chain — caught here
+ * rather than looping forever). Callers reading untrusted storage should use
+ * {@link readDocumentJson}, which turns both into an honest `ok: false`.
+ */
+export function upgradeDocumentJson(doc: EditorDocumentJson): LatestEditorDocumentJson {
+  // Indexed through a widened key on purpose: while the union has a single
+  // member, TypeScript narrows `version` to `never` past the latest-version
+  // check and the record lookup stops being callable. The runtime guard is
+  // the real check regardless — storage can hold any string.
+  const steps: Record<string, UpgradeStep | undefined> = DOCUMENT_JSON_UPGRADES
+
+  let current: EditorDocumentJson = doc
+  // Bounded by the version list: every step must move strictly up the ladder
+  // (enforced below), so the loop can run at most once per version.
+  for (let hops = 0; hops <= DOCUMENT_JSON_VERSIONS.length; hops++) {
+    const version: string = current.version
+    // Sound because the schema ties each `version` literal to its own shape:
+    // a document reporting the newest version parsed as the newest member.
+    if (version === LATEST_DOCUMENT_JSON_VERSION) return current as LatestEditorDocumentJson
+
+    const step = steps[version]
+    if (!step) throw new Error(`Nicht unterstützte Schema-Version: "${version}".`)
+
+    const next = step(current)
+    if (next.version === version) {
+      throw new Error(`Aktualisierung der Schema-Version "${version}" hat die Version nicht erhöht.`)
+    }
+    current = next
+  }
+  throw new Error('Aktualisierung der Schema-Version wurde nicht abgeschlossen.')
+}
+
+/** Outcome of reading a stored snapshot: a usable document, or an honest refusal. */
+export type DocumentJsonReadResult =
+  | { ok: true; doc: LatestEditorDocumentJson }
+  | { ok: false; error: string }
+
+/**
+ * The read boundary for stored document JSON — parse, then upgrade.
+ *
+ * `raw` is whatever came back from the database (or a file): unvalidated
+ * `unknown`. On success the document is guaranteed to be at the newest
+ * version and structurally complete. On failure the caller gets a German
+ * message and NO document, which is the signal to fall back to the stored
+ * PNG rather than render something partial.
+ */
+export function readDocumentJson(raw: unknown): DocumentJsonReadResult {
+  const parsed = DocumentJsonSchema.safeParse(raw)
+  if (!parsed.success) {
+    return { ok: false, error: describeDocumentJsonError(parsed.error, raw) }
+  }
+  try {
+    return { ok: true, doc: upgradeDocumentJson(parsed.data) }
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : 'Dokument konnte nicht aktualisiert werden.',
+    }
+  }
+}

--- a/src/lib/editor/document-version.ts
+++ b/src/lib/editor/document-version.ts
@@ -30,7 +30,6 @@
  */
 
 import {
-  DOCUMENT_JSON_VERSIONS,
   DocumentJsonSchema,
   LATEST_DOCUMENT_JSON_VERSION,
   describeDocumentJsonError,
@@ -55,40 +54,66 @@ export const DOCUMENT_JSON_UPGRADES: Record<DocumentJsonVersion, UpgradeStep> = 
   '1.0': (doc) => doc,
 }
 
+/** Anything the chain walker needs to see: a document carrying a version. */
+interface VersionedDocument {
+  version: string
+}
+
 /**
- * Migrates a schema-valid snapshot up to {@link LATEST_DOCUMENT_JSON_VERSION}.
+ * Walks a document up an upgrade ladder until a step declines to advance it.
  *
- * Throws a German `Error` when the version is outside the supported list, or
- * when a step fails to advance the version (a malformed chain — caught here
- * rather than looping forever). Callers reading untrusted storage should use
- * {@link readDocumentJson}, which turns both into an honest `ok: false`.
+ * The identity step is what TERMINATES this loop, which is the point: it is
+ * load-bearing rather than decorative, so the totality of the step record is
+ * checked at runtime on every read, and a version whose step is missing
+ * cannot slip through as "already newest".
+ *
+ * Generic over the document shape and taking its ladder as a parameter, so
+ * the chain can be tested across a real vN→vN+1 hop while only one version
+ * exists in production. {@link upgradeDocumentJson} is the real entry point.
  */
-export function upgradeDocumentJson(doc: EditorDocumentJson): LatestEditorDocumentJson {
-  // Indexed through a widened key on purpose: while the union has a single
-  // member, TypeScript narrows `version` to `never` past the latest-version
-  // check and the record lookup stops being callable. The runtime guard is
-  // the real check regardless — storage can hold any string.
-  const steps: Record<string, UpgradeStep | undefined> = DOCUMENT_JSON_UPGRADES
-
-  let current: EditorDocumentJson = doc
-  // Bounded by the version list: every step must move strictly up the ladder
-  // (enforced below), so the loop can run at most once per version.
-  for (let hops = 0; hops <= DOCUMENT_JSON_VERSIONS.length; hops++) {
-    const version: string = current.version
-    // Sound because the schema ties each `version` literal to its own shape:
-    // a document reporting the newest version parsed as the newest member.
-    if (version === LATEST_DOCUMENT_JSON_VERSION) return current as LatestEditorDocumentJson
-
+export function upgradeThroughChain<T extends VersionedDocument>(
+  doc: T,
+  steps: Record<string, ((doc: T) => T) | undefined>,
+  latest: string
+): T {
+  let current = doc
+  // Every step must move strictly up the ladder, so the loop can run at most
+  // once per version — the bound just turns a malformed chain into an error
+  // instead of a hang.
+  for (let hops = 0; hops <= Object.keys(steps).length; hops++) {
+    const version = current.version
     const step = steps[version]
     if (!step) throw new Error(`Nicht unterstützte Schema-Version: "${version}".`)
 
     const next = step(current)
     if (next.version === version) {
+      // A step that does not advance is the identity step, and identity is
+      // only correct at the top of the ladder.
+      if (version === latest) return next
       throw new Error(`Aktualisierung der Schema-Version "${version}" hat die Version nicht erhöht.`)
     }
     current = next
   }
   throw new Error('Aktualisierung der Schema-Version wurde nicht abgeschlossen.')
+}
+
+/**
+ * Migrates a schema-valid snapshot up to {@link LATEST_DOCUMENT_JSON_VERSION}.
+ *
+ * Throws a German `Error` when the version is outside the supported list, or
+ * when a step fails to advance the version (a malformed chain). Callers
+ * reading untrusted storage should use {@link readDocumentJson}, which turns
+ * both into an honest `ok: false`.
+ */
+export function upgradeDocumentJson(doc: EditorDocumentJson): LatestEditorDocumentJson {
+  const upgraded = upgradeThroughChain<EditorDocumentJson>(
+    doc,
+    DOCUMENT_JSON_UPGRADES,
+    LATEST_DOCUMENT_JSON_VERSION
+  )
+  // Sound because the schema ties each `version` literal to its own shape: a
+  // document reporting the newest version parsed as the newest union member.
+  return upgraded as LatestEditorDocumentJson
 }
 
 /** Outcome of reading a stored snapshot: a usable document, or an honest refusal. */

--- a/src/lib/editor/publish-plan.test.ts
+++ b/src/lib/editor/publish-plan.test.ts
@@ -1,0 +1,272 @@
+/**
+ * publish-plan tests (#66).
+ *
+ * Behavioural: given a draft snapshot and the images that exist on both
+ * sides, what does publishing have to do? The plan is deliberately pure so
+ * the ORDERING GUARANTEE — build everything new first, swap in one statement,
+ * clean up the old last — can be verified without touching storage.
+ *
+ * Runs in plain Node: no DOM, no Supabase.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { LatestEditorDocumentJson } from './document-json'
+import { planPublish, type DraftImageRef, type StoredImageRef } from './publish-plan'
+
+const DRAFT_IMG_A = '11111111-1111-4111-8111-111111111111'
+const DRAFT_IMG_B = '22222222-2222-4222-8222-222222222222'
+const OLD_DOC_IMG = '33333333-3333-4333-8333-333333333333'
+
+/** Deterministic id/path minting — the action injects the real generators. */
+function fixtures() {
+  let n = 0
+  return {
+    mintImageId: () => `new-id-${++n}`,
+    mintImagePath: ({ index }: { index: number }) => `documents/u1/copy-${index}.png`,
+  }
+}
+
+function docWithImages(...imageIds: string[]): LatestEditorDocumentJson {
+  return {
+    version: '1.0',
+    variables: [],
+    content: [
+      { type: 'paragraph', children: [{ text: 'Vor dem Bild' }] },
+      ...imageIds.map((imageId) => ({ type: 'image' as const, imageId })),
+    ],
+    library: [],
+  }
+}
+
+function planFor(input: {
+  content: LatestEditorDocumentJson
+  draftImages?: DraftImageRef[]
+  previousImages?: StoredImageRef[]
+}) {
+  return planPublish({
+    content: input.content,
+    draftImages: input.draftImages ?? [],
+    previousImages: input.previousImages ?? [],
+    ...fixtures(),
+  })
+}
+
+// ── Documents without images ────────────────────────────────────────────────
+
+describe('planPublish — no images', () => {
+  it('plans nothing to copy and returns the content untouched', () => {
+    const content = docWithImages()
+    const result = planFor({ content })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.copies).toEqual([])
+    expect(result.plan.inserts).toEqual([])
+    expect(result.plan.content).toEqual(content)
+  })
+
+  it('still schedules the previous publish’s images for deletion', () => {
+    const result = planFor({
+      content: docWithImages(),
+      previousImages: [{ id: OLD_DOC_IMG, file_path: 'documents/u1/old.png' }],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.stale.imageIds).toEqual([OLD_DOC_IMG])
+    expect(result.plan.stale.paths).toEqual(['documents/u1/old.png'])
+  })
+})
+
+// ── Copy fresh, then swap ───────────────────────────────────────────────────
+
+describe('planPublish — image re-homing', () => {
+  it('copies every referenced draft image to a fresh document-image path', () => {
+    const result = planFor({
+      content: docWithImages(DRAFT_IMG_A, DRAFT_IMG_B),
+      draftImages: [
+        { id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' },
+        { id: DRAFT_IMG_B, file_path: 'editor-images/d1/b.png' },
+      ],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.copies).toEqual([
+      {
+        draftImageId: DRAFT_IMG_A,
+        documentImageId: 'new-id-1',
+        fromPath: 'editor-images/d1/a.png',
+        toPath: 'documents/u1/copy-0.png',
+        position: 0,
+      },
+      {
+        draftImageId: DRAFT_IMG_B,
+        documentImageId: 'new-id-2',
+        fromPath: 'editor-images/d1/b.png',
+        toPath: 'documents/u1/copy-1.png',
+        position: 1,
+      },
+    ])
+  })
+
+  it('never reuses a draft storage path — the copy is what the document owns', () => {
+    const result = planFor({
+      content: docWithImages(DRAFT_IMG_A),
+      draftImages: [{ id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' }],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    for (const copy of result.plan.copies) expect(copy.toPath).not.toBe(copy.fromPath)
+  })
+
+  it('rewrites the stored JSON to the copies, not the draft images', () => {
+    const result = planFor({
+      content: docWithImages(DRAFT_IMG_A, DRAFT_IMG_B),
+      draftImages: [
+        { id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' },
+        { id: DRAFT_IMG_B, file_path: 'editor-images/d1/b.png' },
+      ],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const ids = result.plan.content.content
+      .filter((b) => b.type === 'image')
+      .map((b) => (b.type === 'image' ? b.imageId : ''))
+    expect(ids).toEqual(['new-id-1', 'new-id-2'])
+    expect(JSON.stringify(result.plan.content)).not.toContain(DRAFT_IMG_A)
+    expect(JSON.stringify(result.plan.content)).not.toContain(DRAFT_IMG_B)
+  })
+
+  it('plans one insert per copy, in content order', () => {
+    const result = planFor({
+      content: docWithImages(DRAFT_IMG_A, DRAFT_IMG_B),
+      draftImages: [
+        { id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' },
+        { id: DRAFT_IMG_B, file_path: 'editor-images/d1/b.png' },
+      ],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.inserts).toEqual([
+      { id: 'new-id-1', file_path: 'documents/u1/copy-0.png', position: 0 },
+      { id: 'new-id-2', file_path: 'documents/u1/copy-1.png', position: 1 },
+    ])
+  })
+
+  it('copies a repeatedly referenced image once and points every block at it', () => {
+    const result = planFor({
+      content: docWithImages(DRAFT_IMG_A, DRAFT_IMG_A),
+      draftImages: [{ id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' }],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.copies).toHaveLength(1)
+    const ids = result.plan.content.content
+      .filter((b) => b.type === 'image')
+      .map((b) => (b.type === 'image' ? b.imageId : ''))
+    expect(ids).toEqual(['new-id-1', 'new-id-1'])
+  })
+
+  it('ignores draft images the document no longer references', () => {
+    const result = planFor({
+      content: docWithImages(DRAFT_IMG_A),
+      draftImages: [
+        { id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' },
+        { id: DRAFT_IMG_B, file_path: 'editor-images/d1/unused.png' },
+      ],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.copies).toHaveLength(1)
+    expect(result.plan.copies[0]?.draftImageId).toBe(DRAFT_IMG_A)
+  })
+
+  it('preserves the other image-block keys and their order (byte stability)', () => {
+    const content: LatestEditorDocumentJson = {
+      version: '1.0',
+      variables: [],
+      content: [{ type: 'image', imageId: DRAFT_IMG_A, alt: 'Diagramm', style: { align: 'center' } }],
+      library: [],
+    }
+    const result = planFor({
+      content,
+      draftImages: [{ id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' }],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(JSON.stringify(result.plan.content.content[0])).toBe(
+      JSON.stringify({ type: 'image', imageId: 'new-id-1', alt: 'Diagramm', style: { align: 'center' } })
+    )
+  })
+
+  it('is pure — the draft snapshot handed in is not mutated', () => {
+    const content = docWithImages(DRAFT_IMG_A)
+    const before = JSON.stringify(content)
+    planFor({ content, draftImages: [{ id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' }] })
+    expect(JSON.stringify(content)).toBe(before)
+  })
+})
+
+// ── Cleanup is scheduled, never interleaved ─────────────────────────────────
+
+describe('planPublish — what gets deleted', () => {
+  it('marks only the PREVIOUS publish’s rows and objects as stale', () => {
+    const result = planFor({
+      content: docWithImages(DRAFT_IMG_A),
+      draftImages: [{ id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' }],
+      previousImages: [{ id: OLD_DOC_IMG, file_path: 'documents/u1/old.png' }],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.stale).toEqual({
+      imageIds: [OLD_DOC_IMG],
+      paths: ['documents/u1/old.png'],
+    })
+  })
+
+  it('never schedules a draft image or a freshly copied object for deletion', () => {
+    // Copy-not-move: the draft must stay editable and re-publishable, so its
+    // objects are never touched by a publish.
+    const result = planFor({
+      content: docWithImages(DRAFT_IMG_A),
+      draftImages: [{ id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' }],
+      previousImages: [{ id: OLD_DOC_IMG, file_path: 'documents/u1/old.png' }],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.stale.paths).not.toContain('editor-images/d1/a.png')
+    expect(result.plan.stale.imageIds).not.toContain(DRAFT_IMG_A)
+    for (const copy of result.plan.copies) {
+      expect(result.plan.stale.paths).not.toContain(copy.toPath)
+    }
+  })
+
+  it('has nothing stale on a first publish', () => {
+    const result = planFor({
+      content: docWithImages(DRAFT_IMG_A),
+      draftImages: [{ id: DRAFT_IMG_A, file_path: 'editor-images/d1/a.png' }],
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.stale).toEqual({ imageIds: [], paths: [] })
+  })
+})
+
+// ── Honest refusal ──────────────────────────────────────────────────────────
+
+describe('planPublish — refusal', () => {
+  it('refuses when the snapshot references an image the draft does not have', () => {
+    // Publishing a document whose picture cannot be re-homed would produce a
+    // student-facing document with a broken image. Fail before anything moves.
+    const result = planFor({
+      content: docWithImages(DRAFT_IMG_A),
+      draftImages: [],
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('Bild')
+  })
+
+  it('carries no plan on the failure branch', () => {
+    const result = planFor({ content: docWithImages(DRAFT_IMG_A), draftImages: [] })
+    expect('plan' in result).toBe(false)
+  })
+})

--- a/src/lib/editor/publish-plan.ts
+++ b/src/lib/editor/publish-plan.ts
@@ -1,0 +1,163 @@
+/**
+ * publish-plan — the copy-fresh-then-swap re-homing plan for publishing an
+ * editor draft as a Document (#66, spec #63 §3).
+ *
+ * Publishing has to move a draft's images into the student-facing world, and
+ * the constraint that decides the whole design is that it must COPY, never
+ * move: `editor_images` rows cascade with their draft, and the draft has to
+ * stay editable and re-publishable. A published document that pointed at
+ * draft images would blank out the moment its draft was deleted.
+ *
+ * The ordering IS the guarantee, and it is the ordering the publish action
+ * already uses for the PNG:
+ *
+ *   1. copy the referenced draft images to fresh document-image paths
+ *   2. insert the document-image rows
+ *   3. rewrite the snapshot's image references to those rows
+ *   4. update the Document row — content + file path — in ONE statement
+ *   5. delete the PREVIOUS publish's rows and objects
+ *
+ * Fail before step 4 and only orphans exist while the live document is
+ * untouched; fail at step 5 and only stale objects remain while the document
+ * is correct. Never the other way round.
+ *
+ * This module is the pure half: it decides what to copy, which references to
+ * rewrite and what to delete, and it decides all of it BEFORE anything is
+ * touched — which is what makes the ordering testable without storage. The
+ * document-image ids are minted here rather than left to the database default
+ * precisely so the rewrite can happen up front, in one pass, with no
+ * round-trip in the middle.
+ *
+ * Pure module: no Supabase, no DOM, no mutation of its input.
+ */
+
+import { collectReferencedImageIds, type LatestEditorDocumentJson } from './document-json'
+
+/** An `editor_images` row of the draft being published. */
+export interface DraftImageRef {
+  id: string
+  file_path: string
+}
+
+/** A `document_images` row of the target Document — the previous publish's copies. */
+export interface StoredImageRef {
+  id: string
+  file_path: string
+}
+
+/** One draft image and the fresh copy it becomes. */
+export interface PlannedImageCopy {
+  /** The `editor_images` row copied FROM — never modified, never deleted. */
+  draftImageId: string
+  /** The `document_images` row id the copy will be inserted with. */
+  documentImageId: string
+  fromPath: string
+  toPath: string
+  position: number
+}
+
+export interface PublishPlan {
+  /** Storage objects to copy, before anything else happens. */
+  copies: PlannedImageCopy[]
+  /** `document_images` rows to insert once the copies exist, in content order. */
+  inserts: { id: string; file_path: string; position: number }[]
+  /** The snapshot to store: every draft image id rewritten to its copy. */
+  content: LatestEditorDocumentJson
+  /**
+   * The PREVIOUS publish's rows and objects. Deleted only AFTER the Document
+   * update succeeds — never the draft's own images (copy-not-move), never a
+   * freshly copied object.
+   */
+  stale: { imageIds: string[]; paths: string[] }
+}
+
+export type PublishPlanResult = { ok: true; plan: PublishPlan } | { ok: false; error: string }
+
+export interface PublishPlanInput {
+  /** The draft's saved snapshot, already parsed and upgraded to the newest version. */
+  content: LatestEditorDocumentJson
+  /** Every `editor_images` row of the draft. Unreferenced ones are ignored. */
+  draftImages: DraftImageRef[]
+  /** Every `document_images` row of the target Document; empty on a first publish. */
+  previousImages: StoredImageRef[]
+  /** Mints the id a copied image's `document_images` row will carry. */
+  mintImageId: () => string
+  /** Mints the storage path a copied image is written to. */
+  mintImagePath: (source: { draftImageId: string; fromPath: string; index: number }) => string
+}
+
+/**
+ * Decides everything a publish must do to the images, before it does any of
+ * it. Returns an honest refusal — and no plan — when the snapshot references
+ * an image the draft does not have: publishing a document whose picture
+ * cannot be re-homed would hand a student a broken image, which is worse
+ * than not publishing at all.
+ */
+export function planPublish(input: PublishPlanInput): PublishPlanResult {
+  const { content, draftImages, previousImages, mintImageId, mintImagePath } = input
+
+  const byDraftImageId = new Map(draftImages.map((img) => [img.id, img]))
+  const referenced = collectReferencedImageIds(content)
+
+  const copies: PlannedImageCopy[] = []
+  // Draft image id → the document-image id its blocks are rewritten to. Built
+  // from the deduped reference list, so an image used twice is copied once and
+  // both blocks land on the same row.
+  const rewrites = new Map<string, string>()
+
+  for (const [index, draftImageId] of referenced.entries()) {
+    const draftImage = byDraftImageId.get(draftImageId)
+    if (!draftImage) {
+      return {
+        ok: false,
+        error:
+          `Das Dokument verweist auf ein Bild, das nicht mehr zum Entwurf gehört (${draftImageId}). ` +
+          'Bitte das Bild erneut einfügen und den Entwurf speichern.',
+      }
+    }
+    const documentImageId = mintImageId()
+    copies.push({
+      draftImageId,
+      documentImageId,
+      fromPath: draftImage.file_path,
+      toPath: mintImagePath({ draftImageId, fromPath: draftImage.file_path, index }),
+      position: index,
+    })
+    rewrites.set(draftImageId, documentImageId)
+  }
+
+  return {
+    ok: true,
+    plan: {
+      copies,
+      inserts: copies.map((c) => ({ id: c.documentImageId, file_path: c.toPath, position: c.position })),
+      content: rewriteImageReferences(content, rewrites),
+      stale: {
+        imageIds: previousImages.map((img) => img.id),
+        paths: previousImages.map((img) => img.file_path),
+      },
+    },
+  }
+}
+
+/**
+ * Replaces every image block's `imageId` with its re-homed counterpart.
+ *
+ * Spreads the block rather than rebuilding it, so the emitted key order is
+ * unchanged — the serializer's export → import → export byte-stability
+ * contract has to keep holding for the stored snapshot too.
+ */
+function rewriteImageReferences(
+  content: LatestEditorDocumentJson,
+  rewrites: Map<string, string>
+): LatestEditorDocumentJson {
+  if (rewrites.size === 0) return content
+  return {
+    ...content,
+    content: content.content.map((block) => {
+      if (block.type !== 'image') return block
+      const documentImageId = rewrites.get(block.imageId)
+      return documentImageId ? { ...block, imageId: documentImageId } : block
+    }),
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,9 +38,24 @@ export interface Document {
   title: string
   description: string | null
   file_path: string | null
-  file_type: 'pdf' | 'image' | 'image_collection'
+  /**
+   * Mirrors the `documents_file_type_check` CHECK constraint
+   * (supabase/add_document_content.sql) — the two must list the same values.
+   * `'interactive'` is a published editor document; the legacy values are
+   * kept because file_type is the restoration key for archived rows.
+   */
+  file_type: 'pdf' | 'image' | 'image_collection' | 'interactive'
   position: number
   created_at: string
+  /**
+   * Published document JSON (#65) — NULL for every legacy row. Validated
+   * against the versioned schema on read via `readDocumentJson`, never
+   * trusted as-is.
+   *
+   * NOT selected by every query: the Unit-page read lists its columns
+   * explicitly so a page that does not render the snapshot does not ship it.
+   */
+  content: unknown
 }
 
 export interface DocumentImage {

--- a/supabase/add_document_content.sql
+++ b/supabase/add_document_content.sql
@@ -1,0 +1,55 @@
+-- add_document_content: the published interactive document (#65, spec #63).
+--
+-- Apply order: migration.sql → add_audit_log.sql → add_entitlements.sql →
+-- add_editor_documents.sql → add_editor_images.sql → THIS FILE.
+--
+-- Prepares the Document row to carry a published interactive document.
+-- Nothing a student or author sees changes; this is the database half of the
+-- foundation.
+--
+-- NO RLS WORK IS NEEDED AND NONE IS ADDED, ON PURPOSE: `documents` SELECT is
+-- already entitlement-gated, so anything stored on the row inherits that gate
+-- with zero new policies. That is exactly why the published JSON lives here
+-- and not on `editor_documents`, which is admin-only on all four verbs and
+-- whose rows are DRAFTS — serving one would break the snapshot contract (an
+-- author mid-edit would silently change what students see).
+
+-- ─────────────────────────────────────────────
+-- 1. The published document JSON
+-- ─────────────────────────────────────────────
+
+-- NULL for every existing row: legacy PDF and image documents carry no
+-- snapshot, and the student renderer treats NULL as "render exactly as it
+-- does today". Written by publishEditorDraft (#66), read by the renderer
+-- (#67) through the versioned schema — never trusted as-is.
+ALTER TABLE public.documents ADD COLUMN IF NOT EXISTS content JSONB;
+
+-- ─────────────────────────────────────────────
+-- 2. file_type gains 'interactive' and a CHECK
+-- ─────────────────────────────────────────────
+
+-- The allowed values have until now lived ONLY in the TypeScript union
+-- (src/types/index.ts) — the database has never seen them. Keep the two in
+-- sync: this CHECK and `Document['file_type']` must list the same values.
+--
+-- file_type is deliberately NOT dropped. It is the restoration key for
+-- retained legacy rows — the only column recording what an archived row used
+-- to be — and `file_type <> 'interactive'` is what makes the archive-selection
+-- query of the cutover (#81) possible.
+--
+-- Pre-flight, if this fails: some row holds a value outside the four below.
+--   SELECT DISTINCT file_type FROM public.documents;
+ALTER TABLE public.documents DROP CONSTRAINT IF EXISTS documents_file_type_check;
+ALTER TABLE public.documents
+  ADD CONSTRAINT documents_file_type_check
+  CHECK (file_type IN ('pdf', 'image', 'image_collection', 'interactive'));
+
+-- ─────────────────────────────────────────────
+-- 3. No index on `content`
+-- ─────────────────────────────────────────────
+
+-- Deliberate. Nothing queries INTO the JSON: a document is always fetched by
+-- primary key, and links resolve by the target's published id (spec #63 §6),
+-- which is a single-row PK fetch rather than a search. A GIN index here would
+-- be write cost for a read that never happens. The backlink scan (#75) reads
+-- content collections in application code, on demand, by design.

--- a/supabase/add_document_content.sql
+++ b/supabase/add_document_content.sql
@@ -4,8 +4,17 @@
 -- add_editor_documents.sql → add_editor_images.sql → THIS FILE.
 --
 -- Prepares the Document row to carry a published interactive document.
--- Nothing a student or author sees changes; this is the database half of the
--- foundation.
+--
+-- ⚠ APPLY THIS BEFORE DEPLOYING THE CODE THAT SHIPS WITH IT. The migration is
+-- backwards-compatible with the OLD code, but the new code is NOT
+-- backwards-compatible with the old schema: `getUnitWithTasks` names `content`
+-- in its select, so until the column exists PostgREST fails the whole query
+-- and EVERY student Unit page 404s — not only pages holding an interactive
+-- document. `publishEditorDraft` writes `content` on both paths and fails
+-- outright. Order is: migrate dev → verify → deploy, and the same for prod.
+--
+-- Beyond that ordering, nothing a student or author sees changes; this is the
+-- database half of the foundation.
 --
 -- NO RLS WORK IS NEEDED AND NONE IS ADDED, ON PURPOSE: `documents` SELECT is
 -- already entitlement-gated, so anything stored on the row inherits that gate


### PR DESCRIPTION
The foundation slice of spec #63 — the four dependency roots that unblock the
remaining twelve agent tickets. A published editor document now renders as live
content for students instead of a flattened picture.

## Summary

- **#64 — versioned schema.** `DocumentJsonSchema` becomes a discriminated union over `version`, and a new pure `document-version.ts` carries the vN→vN+1 chain plus `readDocumentJson`, the single boundary every stored snapshot passes through. It refuses whole — the failure branch carries no document — so a caller can fall back to the PNG instead of rendering something partial.
- **#65 — DB foundation.** `documents.content` JSONB (NULL for every legacy row) and the first `file_type` CHECK, which until now lived only in the TypeScript union. No RLS work and none needed: the row is already entitlement-gated. The Unit-page read lists its columns explicitly instead of `documents(*)`.
- **#66 — publish dual-write.** Title, `file_type='interactive'`, content JSON and PNG path land in one statement; re-publishing keeps the Document id. Images are **copied, never moved** — `editor_images` cascade with their draft — via a pure, unit-tested plan that decides what to copy, rewrite and delete before anything is touched.
- **#67 — student renderer.** A pure `content → DOM` function reusing the editor's importer, field resolver, evaluator and number formatter, so there is no second resolution path. Real selectable text, formulas typeset by the **bundled** MathJax (no CDN, no `eval`, `next.config.ts` untouched), images through the existing entitlement-gated route, German-formatted computed outputs.
- **The PNG is a real per-document runtime fallback, not a feature flag** — reached three ways: the read boundary refusing a snapshot, the renderer throwing, and a class error boundary for render-phase errors (an error thrown in an effect never reaches a boundary on its own).
- **Two consequences closed in the same change**, or the dual-write would have regressed things it never touched: `collectStoragePaths` now treats `interactive` as owning its `document_images` (rows cascade on delete, storage objects do not), and `updateDocument` treats it as metadata-only (uploading a file over one used to flip `file_type` away while leaving the content JSON and re-homed images behind).

## ⚠ Deploy ordering — apply the migration BEFORE deploying

`supabase/add_document_content.sql` is backwards-compatible with the old code, but **the new code is not backwards-compatible with the old schema**. `getUnitWithTasks` names `content` in its select, so until the column exists PostgREST fails the whole query and *every* student Unit page 404s — not only pages holding an interactive document. `publishEditorDraft` writes `content` on both paths and fails outright.

Order is: **migrate → verify → deploy**, per environment.

**Dev: applied and verified.** Tracked in the migration history as `add_document_content`. Pre-flight found only `pdf` and `image` rows, so the CHECK applied cleanly and came back `convalidated = true` — it validated the existing rows rather than deferring to future writes. Verified after: `content` is `jsonb` and nullable, NULL on all existing rows; the constraint reads `file_type = ANY (ARRAY['pdf','image','image_collection','interactive'])`, matching `Document['file_type']` exactly; the DAL's explicit column list selects successfully; RLS still enabled with its five policies untouched, including `View documents of entitled units`, which is the gate this design leans on instead of adding new policies. (`get_advisors` was not run — the MCP server is configured `--features=database,docs`, which excludes it. The migration adds no table and no policy, so there is no new RLS surface for it to flag.)

**Prod: outstanding, and must be applied by hand.** MCP is pinned to the dev project by design and cannot reach prod. Run the same file in the prod SQL editor, after the same pre-flight — `SELECT file_type, count(*) FROM public.documents GROUP BY file_type;` — since prod holds real content and dev held seven rows. This must land **before** the prod deploy.

## Test plan

- `npm test` — **388 pass** (37 new; no existing expectation modified). New suites: `document-version` (chain totality, a synthetic 0.8→0.9→1.0 ladder, refusal of unknown versions/nodes/keys), `publish-plan` (copy-not-move, dedup, key-order-preserving rewrites, what is and is not stale), `document-render` (every block type under jsdom, chrome provably absent, nothing contenteditable, static/computed/reference/error field values).
- The editor's golden parity tests pass **untouched** — they are the port's parity contract with the standalone reference editor.
- `npm run build` — passes.
- `npm run lint` — clean. It was red on ~600 errors from a sibling git worktree's `.next/` build output: the ignore was root-anchored `.next/**`, so ESLint walked into other branches' generated bundles. Now `**/.next/**`. Unrelated to this branch's code, but fixed here so the gate means something at merge time.
- Not covered by tests, needs manual QA: publishing a draft that contains images, and how the rendered document looks on a phone.

## Two unrelated files, carried here deliberately

Neither belongs to #64–#67; both are things applying the migration turned up, small enough that splitting them into their own PR would cost more review than it saves.

- **`eslint.config.mjs`** — the ignore was root-anchored `.next/**`, so ESLint walked into sibling git worktrees' build output under `.claude/worktrees/` and reported ~600 errors against another branch's generated bundles. Now `**/.next/**`.
- **`CLAUDE.md`** — its Supabase MCP section instructed running `get_advisors` after every schema change and regenerating types with `generate_typescript_types`. Neither tool exists: the server runs `--features=database,docs`. The section now lists the six tools that do exist and gives concrete substitutes — catalog queries for verification, and a hand-check of `src/types/index.ts` wherever a TS union mirrors a DB CHECK, which is precisely the `file_type` invariant this PR introduces.

## Follow-up noted, not done here

`domFieldGraph` in `document-render.ts` mirrors the controller's DOM adapter almost line for line. Folding them together means editing the shipped editor, whose behaviour is pinned by parity goldens, so it stays duplicated deliberately — the docblock says so. Extracting the shared adapter is the right follow-up.

Spec #63 stays open: this is 4 of its 19 tickets.

Closes #64
Closes #65
Closes #66
Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
