### PR TITLE
Fix QA bugs #84, #85, #86 from the #83 manual pass

### DIFF
--- a/src/actions/admin/editor-publish.ts
+++ b/src/actions/admin/editor-publish.ts
@@ -36,10 +36,19 @@ import { getAdminUser, parseForm, revalidateAdminPages, sanitise, removeStorageO
  * executes them.
  *
  * `mode: 'update'` (default) updates the linked Document in place when a live
- * link exists — task_id/description/position stay untouched ("in place" =
- * same place; relocation is „Als neues Dokument" + manual delete). Students
+ * link exists — task_id/description/position/TITLE stay untouched ("in place"
+ * = same place; relocation is „Als neues Dokument" + manual delete). Students
  * keep the same Document entry (story 32) and the id never changes, so
- * bookmarks and future links to it stay valid. When the link is dead
+ * bookmarks and future links to it stay valid.
+ *
+ * The title is deliberately excluded from the in-place update (#85). It is
+ * derived from the ExportBar's „Dateiname" field, which is NOT persisted with
+ * the draft and resets to its default on every reload — so re-publishing after
+ * a reload (fix a typo → reopen the draft → update, i.e. the normal editing
+ * loop) silently renamed live student-facing content. First publish still
+ * seeds the title from the filename (story 27, no separate title input);
+ * renaming afterwards goes through `updateDocument`, which #82 keeps expressly
+ * as the rename path for interactive documents. When the link is dead
  * (Document deleted → FK SET NULL, or lost in a race) the same call falls
  * back to creating a new Document. `mode: 'new'` („Als neues Dokument")
  * always creates and RE-LINKS the draft.
@@ -98,11 +107,11 @@ export async function publishEditorDraft(
   }
 
   // ── Resolve the target: update in place, or create ────────────────────────
-  let target: { id: string; file_path: string | null } | null = null
+  let target: { id: string; file_path: string | null; title: string } | null = null
   if (mode === 'update' && draft.published_document_id) {
     const { data: linkedDoc, error: linkedErr } = await supabase
       .from('documents')
-      .select('id, file_path')
+      .select('id, file_path, title')
       .eq('id', draft.published_document_id)
       .single()
 
@@ -174,10 +183,12 @@ export async function publishEditorDraft(
       return { ok: false, error: `Bilder konnten nicht gespeichert werden: ${insertErr}` }
     }
 
-    // Step 4: THE SWAP — content and file path in one statement.
+    // Step 4: THE SWAP — content and file path in one statement. `title` is
+    // deliberately NOT in this update (#85, see the header): the existing
+    // document keeps the name students already see.
     const { error: dbErr } = await supabase
       .from('documents')
-      .update({ title, file_path: pngPath, file_type: 'interactive', content: plan.content })
+      .update({ file_path: pngPath, file_type: 'interactive', content: plan.content })
       .eq('id', target.id)
     if (dbErr) {
       await deleteImageRows(supabase, plan.inserts.map((r) => r.id), 'publishEditorDraft swap rollback')
@@ -199,7 +210,8 @@ export async function publishEditorDraft(
       action: 'update',
       entityType: 'document',
       entityId: target.id,
-      entityTitle: title,
+      // The document's OWN title — the submitted one only named the upload.
+      entityTitle: target.title,
       metadata: {
         editor_document_id: draft_id,
         published_in_place: true,

--- a/src/app/admin/documents/new/page.tsx
+++ b/src/app/admin/documents/new/page.tsx
@@ -13,15 +13,17 @@ export default async function NewDocumentPage({
 
   let defaultTaskId = taskId ?? ''
   // 'interactive' is produced by publishing an editor draft (#66), never
-  // uploaded through this form — an interactive document opened here keeps
-  // its metadata fields and simply offers no file kind.
+  // uploaded through this form. It MUST reach the form as itself (#85/#86):
+  // erasing it to undefined made the form fall back to its 'pdf' default and
+  // render a working file picker whose upload `updateDocument` then discarded,
+  // reporting success. The form gates the file input on this value.
   let editDefaults:
     | {
         title: string
         description: string | null
         position: number
         file_path: string | null
-        file_type?: Exclude<DocumentRow['file_type'], 'interactive'>
+        file_type?: DocumentRow['file_type']
       }
     | undefined
   if (editId) {
@@ -32,7 +34,7 @@ export default async function NewDocumentPage({
         description: data.description,
         position: data.position,
         file_path: data.file_path,
-        file_type: data.file_type === 'interactive' ? undefined : data.file_type,
+        file_type: data.file_type,
       }
       defaultTaskId = data.task_id
     }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,3 +45,43 @@ select,
 textarea {
   font-size: 1rem !important;
 }
+
+/*
+ * MathJax assistive MathML (#84).
+ *
+ * MathJax v3 wraps every <mjx-container> with an <mjx-assistive-mml> copy for
+ * screen readers, and hides it visually through its OWN output stylesheet —
+ * injected as <style id="MJX-SVG-styles"> by the startup pipeline's
+ * `updateDocument()`. We never run that pipeline: mathjax-loader.ts sets
+ * `startup: { typeset: false }` and every call site renders through
+ * `tex2svgPromise` directly, so the stylesheet is never inserted and the
+ * assistive copy falls back to UA defaults — a visible, layout-taking second
+ * rendering of every formula.
+ *
+ * These declarations are MathJax's own (a11y/assistive-mml.ts `styles`),
+ * reproduced verbatim: visually hidden, still exposed to assistive tech. They
+ * live here rather than in editor.css + interactive-document.css because BOTH
+ * surfaces need them and a duplicated copy would be a silent drift hazard;
+ * `mjx-*` are MathJax-owned custom elements, so an unscoped rule cannot reach
+ * anything else in the app. Remove this only if the MathJax startup pipeline
+ * is ever run for real.
+ */
+mjx-assistive-mml {
+  position: absolute !important;
+  top: 0;
+  left: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 1px 0 0 0 !important;
+  border: 0 !important;
+  display: block !important;
+  width: auto !important;
+  overflow: hidden !important;
+  /* The hidden copy must not join a text selection — otherwise copying a
+     document yields every formula twice. */
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+mjx-assistive-mml[display="block"] {
+  width: 100% !important;
+}

--- a/src/components/admin/DocumentForm.tsx
+++ b/src/components/admin/DocumentForm.tsx
@@ -13,12 +13,15 @@ const initialState: FormState = null
 
 type TaskWithUnit = Task & { units: Unit & { kurse: Pick<Kurs, 'title'> } }
 
+/** The kinds this form can actually upload — `interactive` is authored in the editor. */
+type UploadableType = 'pdf' | 'image' | 'image_collection'
+
 type DefaultValues = {
   title: string
   description: string | null
   position: number
   file_path?: string | null
-  file_type?: 'pdf' | 'image' | 'image_collection'
+  file_type?: UploadableType | 'interactive'
 }
 
 export function DocumentForm({
@@ -36,8 +39,11 @@ export function DocumentForm({
 }) {
   const router = useRouter()
   const [fileError, setFileError] = useState<string | null>(null)
-  const [docType, setDocType] = useState<'pdf' | 'image' | 'image_collection'>(
-    defaultValues?.file_type ?? 'pdf'
+  // Only ever read on the create path (the type selector and file input are
+  // hidden while editing a metadata-only kind), so an `interactive` default
+  // just falls back to the same 'pdf' the create form starts on.
+  const [docType, setDocType] = useState<UploadableType>(
+    defaultValues?.file_type === 'interactive' ? 'pdf' : (defaultValues?.file_type ?? 'pdf')
   )
   const [state, action, pending] = useActionState(
     async (_prev: FormState, formData: FormData): Promise<FormState> => {
@@ -61,7 +67,16 @@ export function DocumentForm({
     setFileError(null)
   }
 
-  const isEditingCollection = editId && defaultValues?.file_type === 'image_collection'
+  // Kinds whose file `updateDocument` refuses to replace — the form must not
+  // offer an upload the action silently discards while reporting success
+  // (#86). `image_collection` because its pages are uploaded as a set;
+  // `interactive` because its file IS the published PNG of an editor draft,
+  // and replacing it would flip file_type away while the content JSON and the
+  // re-homed document_images stayed behind. Mirrors the server-side branch in
+  // actions/admin/documents.ts — keep the two lists in step.
+  const editingFileType = editId ? defaultValues?.file_type : undefined
+  const isMetadataOnly =
+    editingFileType === 'image_collection' || editingFileType === 'interactive'
 
   return (
     <form action={action} className="flex flex-col gap-5">
@@ -158,9 +173,11 @@ export function DocumentForm({
       )}
 
       {/* File input */}
-      {isEditingCollection ? (
+      {isMetadataOnly ? (
         <p className="text-xs text-gray-400 rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
-          Bildsammlungen können derzeit nicht bearbeitet werden. Nur Titel, Beschreibung und Position sind änderbar.
+          {editingFileType === 'interactive'
+            ? 'Interaktive Dokumente werden im LaTeX-Editor bearbeitet und dort erneut veröffentlicht. Hier sind nur Titel, Beschreibung und Position änderbar.'
+            : 'Bildsammlungen können derzeit nicht bearbeitet werden. Nur Titel, Beschreibung und Position sind änderbar.'}
         </p>
       ) : docType === 'image_collection' ? (
         <div className="flex flex-col gap-1">

--- a/src/components/admin/DocumentPageClient.tsx
+++ b/src/components/admin/DocumentPageClient.tsx
@@ -9,7 +9,7 @@ type Task = { id: string; unit_id: string; title: string; description: string | 
 type Unit = { id: string; kurs_id: string; title: string; description: string | null; position: number; created_at: string; tasks: Task[] }
 type KursTree = { id: string; title: string; units: Unit[] }
 
-type DefaultValues = { title: string; description: string | null; position: number; file_path?: string | null; file_type?: 'pdf' | 'image' | 'image_collection' }
+type DefaultValues = { title: string; description: string | null; position: number; file_path?: string | null; file_type?: 'pdf' | 'image' | 'image_collection' | 'interactive' }
 
 type Props = {
   kurseTree: KursTree[]

--- a/src/components/admin/editor/ExportBar.tsx
+++ b/src/components/admin/editor/ExportBar.tsx
@@ -41,7 +41,12 @@ import type { EditorTargetKurs } from '@/types'
  * Publish (slice 11, #39 — no reference counterpart): „Als Dokument
  * speichern" sends the same 2×-rendered PNG to publishEditorDraft, targeting
  * the LIVE Kurs → Unit → Task selection. The filename (minus `.png`) seeds
- * the Document title (PRD story 27 — no separate title input). When the
+ * the Document title on the CREATE paths only (PRD story 27 — no separate
+ * title input); an update-in-place leaves the existing title alone, because
+ * this field is not persisted with the draft and resets on reload, so
+ * applying it would silently rename live content (#85). The title still
+ * travels with every request: `mode: 'update'` falls back to creating when
+ * the link is dead, and that path needs it. When the
  * draft is linked, the primary button relabels to „Dokument aktualisieren"
  * (update-in-place default; same Document entry for students, story 32) and
  * a secondary „Als neues Dokument" creates + re-links instead. Size guard:
@@ -242,7 +247,10 @@ export function ExportBar({
       setPublishedDocId(result.data.documentId)
       setPublishStatus({
         kind: 'success',
-        text: result.data.mode === 'created' ? 'Dokument erstellt.' : 'Dokument aktualisiert.',
+        text:
+          result.data.mode === 'created'
+            ? 'Dokument erstellt.'
+            : 'Dokument aktualisiert (Titel unverändert).',
         documentId: result.data.documentId,
       })
       router.refresh() // page props + draft list pick up the fresh link


### PR DESCRIPTION
Fixes the three bugs found during manual QA of #83, before continuing with the wayfinder tickets.

## #84 — Formulas render twice

MathJax v3 wraps every `<mjx-container>` with an `<mjx-assistive-mml>` copy for screen readers and keeps it out of the visual layout through its **own** output stylesheet, injected as `<style id="MJX-SVG-styles">` by the startup pipeline's `updateDocument()`. We never run that pipeline — `mathjax-loader.ts` sets `startup: { typeset: false }` and every call site renders through `tex2svgPromise` — so the stylesheet is never inserted and the assistive copy falls back to UA defaults: a visible, layout-taking second rendering of every formula.

Adds MathJax's own declarations (`a11y/assistive-mml.ts`) to `globals.css`. **Not** duplicated into `editor.css` + `interactive-document.css` as the issue suggested: both surfaces need the rule and two copies would silently drift. `globals.css` is imported once by the root layout and covers both; `mjx-*` are MathJax-owned custom elements, so an unscoped rule cannot reach anything else in the app.

`user-select: none` is part of MathJax's rule and matters here — without it, copying a document yields every formula twice.

## #85 — Re-publishing silently renamed the published document

Took the third direction from the issue. The in-place update no longer writes `title`:

- **First publish** still seeds the title from the filename — story 27's "no separate title input" is intact.
- **Re-publish** leaves the live title alone, so the normal editing loop (fix a typo → reopen the draft → update) can no longer rename student-facing content.
- **Renaming** goes through `update-document`, which #82 keeps expressly as the rename path for interactive documents.

The title still travels with every request: `mode: 'update'` falls back to *create* when the link is dead, and that path needs it. The audit log now records the document's own title rather than the upload's.

The success message reads „Dokument aktualisiert (Titel unverändert)." so the behaviour is visible rather than merely silent-in-the-other-direction.

## #86 — File input offered for interactive documents

The root cause sat one level above the reported line. `documents/new/page.tsx` deliberately mapped `interactive` → `undefined`, intending "offers no file kind" — but `DocumentForm` reads that as absent and falls back to its `'pdf'` default, which renders a working file picker. The upload was then discarded server-side while the UI reported success.

`file_type` now reaches the form as itself, and the gate covers both metadata-only kinds, mirroring the branch `updateDocument` already takes. Interactive documents get their own notice pointing at the editor instead of the image-collection wording.

## Verification (dev, live browser)

| | Before (issue) | After |
|---|---|---|
| #84 assistive node | `position: static`, `clip: auto`, 709×38 box taking layout | `position: absolute`, `clip: rect(1px,1px,1px,1px)`, formula block height == SVG height exactly (23px) |
| #85 re-publish | title became `C1_Unit1_MC1` | renamed to `PR84-86 QA Title Keeper`, re-published with filename `ZZZ_Overwrite_Attempt_2.png` → title unchanged |
| #86 interactive edit page | file picker present, "erfolgreich aktualisiert" on discarded upload | zero file inputs, editor notice shown |

Gates: `tsc --noEmit` clean · `npm run lint` clean · **388/388** tests · `npm run build` succeeds.

Note: dev data changed as a side effect of the #85 test — document `7f1302a0…` is now titled `PR84-86 QA Title Keeper`.

Closes #84
Closes #85
Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
