### PR TITLE
Give every Dokument its own addressable full-page URL (#69)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ npm run lint     # ESLint (eslint-config-next 16)
 npm test         # Vitest (dev-only) — colocated *.test.ts unit tests
 ```
 
-Tests run via Vitest ([vitest.config.ts](vitest.config.ts)): colocated `*.test.ts` files next to their modules, currently the editor modules in [src/lib/editor/](src/lib/editor/). Default environment is plain Node; DOM-dependent suites opt into jsdom per file via a `@vitest-environment jsdom` docblock (currently `document-json.test.ts`). The editor-module tests are golden cases derived from the standalone reference editor ([latexEditor/](latexEditor/)) and act as the port's parity contract — don't "fix" expected values without checking the reference behavior.
+Tests run via Vitest ([vitest.config.ts](vitest.config.ts)): colocated `*.test.ts` files next to their modules — the editor modules in [src/lib/editor/](src/lib/editor/), plus any other pure module (e.g. [src/lib/document-view.ts](src/lib/document-view.ts)). There is no component or E2E seam; UI behaviour is verified by manual QA on the ticket. Default environment is plain Node; DOM-dependent suites opt into jsdom per file via a `@vitest-environment jsdom` docblock (currently `document-json.test.ts`). The editor-module tests are golden cases derived from the standalone reference editor ([latexEditor/](latexEditor/)) and act as the port's parity contract — don't "fix" expected values without checking the reference behavior.
 
 ## Stack
 

--- a/DEVELOPER_OVERVIEW.md
+++ b/DEVELOPER_OVERVIEW.md
@@ -122,6 +122,10 @@ src/
 │   │           ├── page.tsx       # Unit detail (expandable task/document tree)
 │   │           ├── error.tsx
 │   │           └── loading.tsx
+│   ├── dokumente/[docId]/         # Addressable single-Dokument route (#69) — flat by design
+│   │   ├── page.tsx               #   full-page view: RLS entitlement + published re-check → DocumentBody
+│   │   ├── error.tsx
+│   │   └── loading.tsx
 │   ├── admin/
 │   │   ├── page.tsx               # Admin hub (4-card grid)
 │   │   ├── error.tsx
@@ -160,6 +164,7 @@ src/
 │   │   ├── KursCard.tsx
 │   │   └── UnitCard.tsx
 │   ├── documents/
+│   │   ├── DocumentBody.tsx        # A document's body for every file_type — the ONE render path shared by the Unit accordion and the full-page route (callers supply the heading)
 │   │   ├── DocumentCard.tsx
 │   │   ├── InteractiveDocument.tsx # Live student render of a published document JSON + PNG fallback (error boundary); owns only the MathJax half — typesets the formulas each recompute reports as changed, serialised so a fast typist cannot land a stale one
 │   │   ├── DocumentPng.tsx        #   the stored picture: legacy 'image' render AND the interactive fallback
@@ -175,6 +180,7 @@ src/
 ├── lib/
 │   ├── constants.ts               # Centralized config (bucket, file limits, MIME types)
 │   ├── dal.ts                     # Data access layer — all Supabase read queries
+│   ├── document-view.ts           # documentViewKind(): which render path a Document takes (interactive | picture | collection | file) — pure, shared by both student surfaces
 │   ├── schemas.ts                 # Zod schemas for server action input validation
 │   ├── audit.ts                   # logAdminAction() — fire-and-forget audit log writer
 │   ├── editor/                    # LaTeX editor (PRD #28): TWO imperative surfaces (controller.ts for /admin/editor, document-render.ts for the student viewer) + pure modules
@@ -281,6 +287,17 @@ The document routes verify:
 
 Short-lived signed URLs (60s) are generated server-side. The document routes respond with a single 302 redirect to the signed URL (the link dies after 60 s); the editor-image route instead fetches it server-side and **streams** the body, so the browser only ever sees a same-origin response — that is what lets the PNG export (html2canvas) rasterise editor images without CORS handling or canvas tainting. Signed Supabase URLs are never stored, embedded in content, or exposed beyond that one redirect.
 
+### Student Document Routes
+
+A Dokument is addressable at `/dokumente/[docId]` (`documentUrl()`), rendered full-page. The segment is **flat on purpose**: a link stores its target's document id and nothing else, so the URL needs no Kurs or Unit in it, and a top-level segment is the shape the overlay's intercepting route will need.
+
+Access reuses the two mechanisms that already exist and adds none:
+
+1. **Entitlement is RLS's job** — `documents` SELECT requires a purchase for the owning Unit (or admin), so an unentitled visitor's query returns no row.
+2. **`kurse.published` is re-checked in app code**, with an admin bypass, exactly as `/api/file` does — the document policies deliberately dropped the `published` subquery, so this app-level check is what makes an archived Kurs dark.
+
+Every failure — unknown id, no entitlement, archived Kurs — lands on the same `notFound()`; distinguishing them would leak which documents exist to someone who cannot read them.
+
 ### Error & Loading Boundaries
 
 Every major route segment has scoped `error.tsx` and `loading.tsx` files. A failed Supabase query shows a friendly German error UI instead of a white screen.
@@ -328,6 +345,7 @@ All magic values live in `src/lib/constants.ts`:
 | `ALLOWED_FILE_MIMES` | `['application/pdf', ...]` | Accepted file types |
 | `MIME_TO_EXT` | `Record<string, string>` | MIME → file extension map |
 | `editorImageUrl(imageId)` | `` `/api/editor-image/${imageId}` `` | Single source for editor-image browser URLs (controller, JSON importer, proxy route) |
+| `documentUrl(docId)` | `` `/dokumente/${docId}` `` | Single source for the addressable Dokument URL (#69) — the accordion's „Einzelansicht", `DocumentCard`, and every future link chip |
 
 ## Dependencies
 
@@ -376,6 +394,8 @@ npm run test:watch   # watch mode
 ```
 
 Conventions: tests are colocated `*.test.ts` files next to their modules and assert **external behavior only** (inputs → outputs, no internal call structure). The default environment is plain Node; DOM-dependent suites opt into jsdom per file via a `@vitest-environment jsdom` docblock — currently `document-json.test.ts`, whose importer builds real DOM. The editor-module tests under `src/lib/editor/` are golden cases generated from the standalone reference editor (`latexEditor/*.html`) and double as the React port's parity contract — expected values must not be changed without checking the reference behavior first.
+
+Tests are not confined to `src/lib/editor/`: any pure module is a candidate, and `src/lib/document-view.test.ts` pins the render-path rule both student surfaces share. React components have no test seam here (no testing-library, no browser E2E) — component and navigation behaviour is verified by manual QA recorded on the ticket.
 
 ### Two Supabase Projects
 
@@ -442,6 +462,8 @@ Set `published = true/false` in the `kurse` table. The Kurs and its Units appear
 |-------|--------------|-----|
 | Admin page accessible without being admin | Proxy not running | Check `src/proxy.ts` exists at `src/` root (Next.js 16 renamed middleware → proxy) |
 | File proxy returns 403 | Course not published | Set `kurse.published = true` for the parent course |
+| `/dokumente/[docId]` 404s for a user who can see the document in the accordion | Parent Kurs unpublished — the route re-checks `published` in app code (admins bypass) | Set `kurse.published = true`, or confirm the 404 is intended (archived Kurs) |
+| `/dokumente/[docId]` 404s for everyone including admins | No such document id | The route deliberately does not distinguish unknown / unentitled / archived — check the id against `documents` |
 | Zod error on form submit | Field name mismatch | Check form field `name` attributes match schema keys in `schemas.ts` |
 | Audit log not writing | `audit_logs` table missing | Apply `supabase/add_audit_log.sql` migration |
 | PDF won't open in iPhone Safari | Content-Disposition | Route sets `{ download: false }` in signed URL — ensure it stays |
@@ -470,6 +492,7 @@ Set `published = true/false` in the `kurse` table. The Kurs and its Units appear
 | Admin form components | `src/components/admin/{Kurs,Unit,Task,Document}Form.tsx` |
 | Admin tree visualizer | `src/components/admin/AdminTree.tsx` |
 | File proxy routes | `src/app/api/file/[docId]/route.ts`, `src/app/api/image/[imageId]/route.ts`, `src/app/api/editor-image/[imageId]/route.ts` |
+| Student document rendering | `src/lib/document-view.ts`, `src/components/documents/DocumentBody.tsx`, `src/app/dokumente/[docId]/page.tsx` |
 | LaTeX editor core (controller + pure modules) | `src/lib/editor/*` |
 | LaTeX editor UI (page, shell, toolbar, export, drafts) | `src/app/admin/editor/*`, `src/components/admin/editor/*` |
 | Standalone reference editor (parity ground truth) | `latexEditor/*.html` |

--- a/src/app/dokumente/[docId]/error.tsx
+++ b/src/app/dokumente/[docId]/error.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+export default function DocumentError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-20 text-center">
+      <h2 className="text-xl font-semibold text-gray-900">Dokument konnte nicht geladen werden.</h2>
+      <p className="mt-2 text-sm text-gray-500">Bitte versuche es erneut.</p>
+      <button
+        onClick={reset}
+        className="mt-6 rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 transition-colors"
+      >
+        Erneut versuchen
+      </button>
+    </div>
+  )
+}

--- a/src/app/dokumente/[docId]/loading.tsx
+++ b/src/app/dokumente/[docId]/loading.tsx
@@ -1,0 +1,10 @@
+export default function DocumentLoading() {
+  return (
+    <div className="mx-auto max-w-5xl px-8 py-10 sm:px-12 lg:px-16">
+      <div className="mb-8 h-4 w-28 rounded bg-gray-100 animate-pulse" />
+      <div className="h-3 w-56 rounded bg-gray-100 animate-pulse" />
+      <div className="mt-2 h-9 w-80 rounded-md bg-gray-100 animate-pulse" />
+      <div className="mt-8 h-64 rounded-md bg-gray-100 animate-pulse" />
+    </div>
+  )
+}

--- a/src/app/dokumente/[docId]/page.tsx
+++ b/src/app/dokumente/[docId]/page.tsx
@@ -1,0 +1,108 @@
+import { cache } from 'react'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { getDocumentWithAncestry } from '@/lib/dal'
+import { createClient } from '@/lib/supabase/server'
+import { DocumentBody } from '@/components/documents/DocumentBody'
+import type { DocumentWithAncestry } from '@/types'
+
+interface Props {
+  params: Promise<{ docId: string }>
+}
+
+// The page and its metadata need the same row; `cache` collapses that into one
+// query per request. It lives here rather than in the DAL because it is this
+// page↔metadata pair that reads twice, not the query itself.
+const loadDocument = cache(getDocumentWithAncestry)
+
+/**
+ * The one app-level access rule of this route: an archived (unpublished) Kurs
+ * is dark to everyone but an admin. Entitlement is not checked here — RLS
+ * already refused the row to anyone without one — and `published` is, because
+ * the document policies deliberately dropped that subquery.
+ */
+function isReadable(view: DocumentWithAncestry, isAdmin: boolean): boolean {
+  return isAdmin || view.kurs.published
+}
+
+/**
+ * The addressable full-page view of a single Dokument (#69) — what a pasted,
+ * bookmarked or shared URL opens.
+ *
+ * ACCESS IS ENFORCED BY THE EXISTING RULES AND NO NEW ONE. The entitlement
+ * check is RLS's: `documents` SELECT already requires a purchase for the
+ * owning Unit (or admin), so an unentitled visitor's query returns nothing
+ * here just as it does everywhere else. On top of that the parent Kurs's
+ * `published` flag is re-checked in app code with an admin bypass, exactly as
+ * /api/file does — that re-check is what actually makes an archived Kurs dark,
+ * since the document policies deliberately dropped the `published` subquery.
+ *
+ * Every failure — unknown id, no entitlement, archived Kurs — lands on the
+ * same 404. Distinguishing them here would leak which documents exist to
+ * someone who cannot read them; telling a student "this is in Einheit 3,
+ * unlock it" is a separate, deliberately server-side surface (#74).
+ */
+export default async function DocumentPage({ params }: Props) {
+  const { docId } = await params
+
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  // The proxy already redirects unauthenticated visitors to the login page;
+  // guard defensively in case the matcher is ever loosened.
+  if (!user) notFound()
+
+  const isAdmin = user.app_metadata?.['role'] === 'admin'
+  const view = await loadDocument(docId)
+  if (!view || !isReadable(view, isAdmin)) notFound()
+
+  const { document, task, unit, kurs } = view
+  const watermarkId = user.id.slice(0, 8).toUpperCase()
+  // Back into the hierarchy at the task this document sits in — the Unit
+  // page's existing deep-link parameter opens that accordion section.
+  const backHref = `/kurse/${kurs.id}/units/${unit.id}?openTask=${task.id}`
+
+  return (
+    <div
+      className="-mx-4 border-t border-gray-200 bg-[#fffdf8] sm:-mx-8"
+      style={{ minHeight: 'calc(100svh - 66px)' }}
+    >
+      <div className="mx-auto max-w-5xl px-8 py-10 sm:px-12 lg:px-16">
+        <Link
+          href={backHref}
+          className="mb-8 inline-block text-sm font-medium text-gray-500 hover:text-gray-700"
+        >
+          ← {unit.title}
+        </Link>
+        {/* Someone arriving from a bookmark or a classmate's link has no
+            history behind them, so the document says where it lives. */}
+        <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+          {kurs.title} · {unit.title} · {task.title}
+        </p>
+        <h1 className="mt-1 text-4xl font-black tracking-[0] text-black">{document.title}</h1>
+        {document.description && (
+          <p className="mt-3 max-w-2xl text-base leading-relaxed text-gray-600">
+            {document.description}
+          </p>
+        )}
+        <div className="mt-6">
+          <DocumentBody doc={document} watermarkId={watermarkId} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// A bookmark is only useful if it carries the document's name. It falls back
+// to the layout's title whenever the page itself would 404 — metadata must not
+// become a way to learn a title the page refuses to show.
+//
+// The same rule as the page, evaluated as though the reader were NOT an admin:
+// resolving the role here would cost an auth round-trip on every load, and all
+// that rides on it is an admin's tab title for an archived document.
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { docId } = await params
+  const view = await loadDocument(docId)
+  if (!view || !isReadable(view, false)) return {}
+  return { title: `${view.document.title} – Dokum` }
+}

--- a/src/components/UnitDetailClient.tsx
+++ b/src/components/UnitDetailClient.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import type { Task, DocumentWithImages } from '@/types'
-import { DocumentPng } from '@/components/documents/DocumentPng'
-import { InteractiveDocument } from '@/components/documents/InteractiveDocument'
-import { Watermark } from '@/components/documents/Watermark'
+import { DocumentBody } from '@/components/documents/DocumentBody'
+import { documentViewKind } from '@/lib/document-view'
+import { documentUrl } from '@/lib/constants'
 import Lightbox from 'yet-another-react-lightbox'
 import Zoom from 'yet-another-react-lightbox/plugins/zoom'
 import 'yet-another-react-lightbox/styles.css'
@@ -93,86 +94,49 @@ export default function UnitDetailClient({ tasks, openTaskId, watermarkId }: { t
                     <p className="px-3 text-xs text-gray-400">No documents yet.</p>
                   ) : (
                     <ul className="space-y-1">
-                      {task.documents.map((doc) => (
-                        <li
-                          key={doc.id}
-                          className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2"
-                        >
-                          {doc.file_type === 'image_collection' ? (
-                            <div>
-                              <p className="text-sm font-medium text-gray-800">{doc.title}</p>
-                              {doc.description && (
-                                <p className="text-xs text-gray-500">{doc.description}</p>
-                              )}
-                              <div className="mt-2 grid grid-cols-1 gap-2">
-                                {(doc.document_images ?? []).map((img) => (
-                                  <div key={img.id} className="mt-1 flex w-full justify-center">
-                                    <div
-                                      className="relative inline-block rounded-md overflow-hidden max-w-full"
-                                      onContextMenu={(e) => e.preventDefault()}
-                                    >
-                                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                                    <img
-                                      src={`/api/image/${img.id}`}
-                                      alt={doc.title}
-                                      className="block max-w-full max-h-[400px] select-none"
-                                      style={{ pointerEvents: 'none', userSelect: 'none', WebkitUserDrag: 'none' } as React.CSSProperties}
-                                      draggable={false}
-                                    />
-                                    <Watermark id={watermarkId} />
-                                    </div>
-                                  </div>
-                                ))}
+                      {task.documents.map((doc) => {
+                        // The body of every document kind lives in
+                        // DocumentBody, shared with the full-page route (#69).
+                        // Only the layout around it differs here: a PDF puts
+                        // its button beside the title, everything else stacks.
+                        const heading = (
+                          <div>
+                            <p className="text-sm font-medium text-gray-800">{doc.title}</p>
+                            {doc.description && (
+                              <p className="text-xs text-gray-500">{doc.description}</p>
+                            )}
+                            <Link
+                              href={documentUrl(doc.id)}
+                              className="mt-0.5 inline-block text-xs text-gray-400 hover:text-brand"
+                            >
+                              Einzelansicht ↗
+                            </Link>
+                          </div>
+                        )
+                        return (
+                          <li
+                            key={doc.id}
+                            className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2"
+                          >
+                            {documentViewKind(doc) === 'file' ? (
+                              <div className="flex items-center justify-between gap-4">
+                                {heading}
+                                {/* The accordion's scale, applied by the
+                                    accordion: the button inherits text-xs and
+                                    the wrapper keeps it from being squeezed. */}
+                                <div className="shrink-0 text-xs">
+                                  <DocumentBody doc={doc} watermarkId={watermarkId} />
+                                </div>
                               </div>
-                            </div>
-                          ) : doc.file_type === 'interactive' && doc.content != null ? (
-                            // A published editor document renders LIVE (#67):
-                            // real text, typeset formulas, resolved values.
-                            // The dual-written PNG stays as the per-document
-                            // fallback, handled inside InteractiveDocument.
-                            <div>
-                              <p className="text-sm font-medium text-gray-800">{doc.title}</p>
-                              {doc.description && (
-                                <p className="text-xs text-gray-500">{doc.description}</p>
-                              )}
-                              <InteractiveDocument
-                                docId={doc.id}
-                                title={doc.title}
-                                content={doc.content}
-                                watermarkId={watermarkId}
-                              />
-                            </div>
-                          ) : doc.file_type === 'image' || doc.file_type === 'interactive' ? (
-                            // A legacy image document, and an interactive one
-                            // whose snapshot was never stored — both are just
-                            // the picture, exactly as they render today.
-                            <div>
-                              <p className="text-sm font-medium text-gray-800">{doc.title}</p>
-                              {doc.description && (
-                                <p className="text-xs text-gray-500">{doc.description}</p>
-                              )}
-                              <DocumentPng docId={doc.id} title={doc.title} watermarkId={watermarkId} />
-                            </div>
-                          ) : (
-                            <div className="flex items-center justify-between gap-4">
+                            ) : (
                               <div>
-                                <p className="text-sm font-medium text-gray-800">{doc.title}</p>
-                                {doc.description && (
-                                  <p className="text-xs text-gray-500">{doc.description}</p>
-                                )}
+                                {heading}
+                                <DocumentBody doc={doc} watermarkId={watermarkId} />
                               </div>
-                              <a
-                                href={`/api/file/${doc.id}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="shrink-0 rounded-md border border-brand px-3 py-1.5 text-xs font-medium text-brand hover:bg-brand/5 transition-colors btn-brand"
-                              >
-                                Open PDF ↗
-                              </a>
-                            </div>
-                          )}
-                        </li>
-                      ))}
+                            )}
+                          </li>
+                        )
+                      })}
                     </ul>
                   )}
                 </div>

--- a/src/components/documents/DocumentBody.tsx
+++ b/src/components/documents/DocumentBody.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import type { RenderableDocument } from '@/types'
+import { documentViewKind } from '@/lib/document-view'
+import { DocumentPng } from './DocumentPng'
+import { InteractiveDocument } from './InteractiveDocument'
+import { Watermark } from './Watermark'
+
+/**
+ * A document's body — everything below its title — for every `file_type`
+ * there is.
+ *
+ * Two surfaces render documents: the Unit accordion and the addressable
+ * full-page route (#69). They differ in their chrome (heading size, the way
+ * back, the URL) and in nothing else, so the body lives here once. That is
+ * what keeps "one content type, one render path" (#63) true in the code and
+ * not merely on the student's screen — a new node type or a changed fallback
+ * lands on both surfaces or on neither.
+ *
+ * The caller supplies the heading and the surrounding layout, because the two
+ * surfaces genuinely disagree about them: a PDF row in the accordion puts its
+ * small button beside the title, while the full page stacks everything at page
+ * scale. Nothing here carries a size or a flex class for that reason — the
+ * PDF button inherits its font size from whichever surface renders it.
+ */
+export function DocumentBody({
+  doc,
+  watermarkId,
+}: {
+  doc: RenderableDocument
+  watermarkId: string
+}) {
+  switch (documentViewKind(doc)) {
+    case 'interactive':
+      // A published editor document renders LIVE (#67): real text, typeset
+      // formulas, resolved values, inputs the student can change (#68). The
+      // dual-written PNG stays as the per-document runtime fallback, handled
+      // inside InteractiveDocument.
+      return (
+        <InteractiveDocument
+          docId={doc.id}
+          title={doc.title}
+          content={doc.content}
+          watermarkId={watermarkId}
+        />
+      )
+
+    case 'picture':
+      // A legacy image document, and an interactive one whose snapshot was
+      // never stored — both are just the picture.
+      return <DocumentPng docId={doc.id} title={doc.title} watermarkId={watermarkId} />
+
+    case 'collection':
+      return (
+        <div className="mt-2 grid grid-cols-1 gap-2">
+          {(doc.document_images ?? []).map((img) => (
+            <div key={img.id} className="mt-1 flex w-full justify-center">
+              <div
+                className="relative inline-block rounded-md overflow-hidden max-w-full"
+                onContextMenu={(e) => e.preventDefault()}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={`/api/image/${img.id}`}
+                  alt={doc.title}
+                  className="block max-w-full max-h-[400px] select-none"
+                  style={
+                    {
+                      pointerEvents: 'none',
+                      userSelect: 'none',
+                      WebkitUserDrag: 'none',
+                    } as React.CSSProperties
+                  }
+                  draggable={false}
+                />
+                <Watermark id={watermarkId} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )
+
+    case 'file':
+      return (
+        <a
+          href={`/api/file/${doc.id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block rounded-md border border-brand px-3 py-1.5 font-medium text-brand hover:bg-brand/5 transition-colors btn-brand"
+        >
+          Open PDF ↗
+        </a>
+      )
+  }
+}

--- a/src/components/documents/DocumentCard.tsx
+++ b/src/components/documents/DocumentCard.tsx
@@ -1,12 +1,14 @@
-// CURRENTLY UNUSED — no page imports this component.
-// The target route /documents/[id] does not exist yet.
+// CURRENTLY UNUSED — no page imports this component. Its target route does
+// exist now (#69); the link is built from the same helper as every other
+// document URL so this cannot drift out of date a second time.
 import Link from 'next/link'
 import type { Document } from '@/types'
+import { documentUrl } from '@/lib/constants'
 
 export function DocumentCard({ document }: { document: Document }) {
   return (
     <Link
-      href={`/documents/${document.id}`}
+      href={documentUrl(document.id)}
       className="block rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition hover:shadow-md hover:border-gray-300"
     >
       <h2 className="text-base font-semibold text-gray-900">{document.title}</h2>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,3 +28,12 @@ export const MIME_TO_EXT: Record<string, string> = {
 export function editorImageUrl(imageId: string): string {
   return `/api/editor-image/${imageId}`
 }
+
+// The addressable URL of a single Dokument (#69) — the thing a student
+// bookmarks or sends to a classmate. Deliberately FLAT: a link stores the
+// target's document id and nothing else (#63 §6), so the URL needs no Kurs or
+// Unit in it, and a top-level segment is also the shape the overlay's
+// intercepting route needs (#70).
+export function documentUrl(docId: string): string {
+  return `/dokumente/${docId}`
+}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -1,6 +1,9 @@
 import 'server-only'
 import { createClient } from '@/lib/supabase/server'
 import type {
+  Document,
+  DocumentImage,
+  DocumentWithAncestry,
   EditorDocument,
   EditorDocumentListItem,
   EditorTargetKurs,
@@ -221,6 +224,72 @@ export async function getDocumentById(
     .eq('id', docId)
     .single()
   return data ?? null
+}
+
+// Full-page document view (#69). Returns the document TOGETHER WITH the
+// ancestry the page needs — the parent Kurs's `published` flag to enforce
+// access, and the Kurs/Unit/Task ids and titles to render the way back into
+// the hierarchy. One round-trip, because the page cannot show anything until
+// all of it has arrived.
+//
+// Access is enforced by the same two mechanisms as everywhere else, not by
+// new ones. RLS on `documents` already requires an entitlement for the owning
+// Unit (or admin), so an unentitled reader gets no row at all; the `!inner`
+// join up to `kurse` additionally drops the row when the Kurs is unpublished,
+// since the `units` policy gates on it. The caller re-checks `published` in
+// app code with an admin bypass anyway, exactly as /api/file does — the
+// archive must not depend on a join's emptiness alone.
+//
+// `content` IS selected here: this page's whole job is rendering the snapshot.
+// `file_path` is NOT — the renderers address the stored file and every image
+// through the proxy routes by id, so a storage path would cross to the browser
+// for nothing.
+export async function getDocumentWithAncestry(docId: string): Promise<DocumentWithAncestry | null> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('documents')
+    .select(
+      `id, title, description, file_type, content,
+       document_images(id, position, created_at),
+       tasks!inner(
+         id, title,
+         units!inner(
+           id, title,
+           kurse!inner(id, title, published)
+         )
+       )`
+    )
+    .eq('id', docId)
+    .single()
+  if (error || !data) return null
+
+  // Deep nested joins are not inferred without generated types; the `!inner`
+  // joins guarantee the relations exist, and the shape is pinned by the row
+  // type right here — the one cast in this function.
+  const { tasks: task, document_images: images, ...document } = data as unknown as DocumentAncestryRow
+  return {
+    document: { ...document, document_images: sortByPosition(images ?? []) },
+    task: { id: task.id, title: task.title },
+    unit: { id: task.units.id, title: task.units.title },
+    kurs: { id: task.units.kurse.id, title: task.units.kurse.title, published: task.units.kurse.published },
+  }
+}
+
+// The raw PostgREST shape of the query above: the document's own columns plus
+// its embedded images and ancestry, which the function immediately splits
+// apart. `position`/`created_at` ride along on the images only so the DAL can
+// apply the hierarchy's sort here, as it does everywhere else.
+type DocumentAncestryRow = Pick<Document, 'id' | 'title' | 'description' | 'file_type' | 'content'> & {
+  document_images: Pick<DocumentImage, 'id' | 'position' | 'created_at'>[] | null
+  tasks: {
+    id: string
+    title: string
+    units: {
+      id: string
+      title: string
+      kurse: { id: string; title: string; published: boolean }
+    }
+  }
 }
 
 // Used by /api/file/[docId] route

--- a/src/lib/document-view.test.ts
+++ b/src/lib/document-view.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { documentViewKind } from './document-view'
+
+/**
+ * The rule these cases pin down is the spec's dual-write contract (#63 §3):
+ * a published interactive document PREFERS its JSON snapshot and falls back
+ * to the stored picture, and every legacy file_type keeps rendering exactly
+ * as it does today. Both the Unit accordion and the full-page document route
+ * (#69) branch on this one function, so the two surfaces cannot drift.
+ */
+describe('documentViewKind', () => {
+  it('renders a published interactive document from its snapshot', () => {
+    expect(documentViewKind({ file_type: 'interactive', content: { version: '1.0' } })).toBe(
+      'interactive'
+    )
+  })
+
+  it('falls back to the picture when an interactive document has no snapshot', () => {
+    expect(documentViewKind({ file_type: 'interactive', content: null })).toBe('picture')
+    expect(documentViewKind({ file_type: 'interactive', content: undefined })).toBe('picture')
+  })
+
+  it('treats a legacy image document as the picture', () => {
+    expect(documentViewKind({ file_type: 'image', content: null })).toBe('picture')
+  })
+
+  it('ignores a snapshot on a legacy row rather than rendering it live', () => {
+    // Defensive: `content` is only ever written together with
+    // file_type = 'interactive'. If the two ever disagree, file_type wins —
+    // a legacy row must not start rendering through the live path.
+    expect(documentViewKind({ file_type: 'image', content: { version: '1.0' } })).toBe('picture')
+    expect(documentViewKind({ file_type: 'pdf', content: { version: '1.0' } })).toBe('file')
+  })
+
+  it('renders an image collection as its own kind', () => {
+    expect(documentViewKind({ file_type: 'image_collection', content: null })).toBe('collection')
+  })
+
+  it('renders a PDF as a downloadable file', () => {
+    expect(documentViewKind({ file_type: 'pdf', content: null })).toBe('file')
+  })
+})

--- a/src/lib/document-view.ts
+++ b/src/lib/document-view.ts
@@ -1,0 +1,39 @@
+import type { Document } from '@/types'
+
+/**
+ * How a Document is presented to a student. Pure and free of `server-only`
+ * so both the server page and the client accordion can branch on it.
+ */
+export type DocumentViewKind =
+  /** A published editor document with a snapshot — rendered live (#67). */
+  | 'interactive'
+  /** The stored picture: a legacy `image`, or an interactive row whose snapshot is missing. */
+  | 'picture'
+  /** A legacy image collection — its `document_images`, in order. */
+  | 'collection'
+  /** A legacy PDF — opened through the signed-file proxy. */
+  | 'file'
+
+/**
+ * The single place the "which render path?" question is answered.
+ *
+ * `file_type` decides first and `content` only ever refines the interactive
+ * case, so a legacy row can never fall into the live path by accident. The
+ * interactive → picture fallback here is the STORED one (no snapshot was
+ * written); the runtime one — a snapshot this build cannot render — lives
+ * inside `InteractiveDocument`, which is the only place that can discover it.
+ */
+export function documentViewKind(
+  doc: Pick<Document, 'file_type'> & { content?: unknown }
+): DocumentViewKind {
+  switch (doc.file_type) {
+    case 'image_collection':
+      return 'collection'
+    case 'interactive':
+      return doc.content != null ? 'interactive' : 'picture'
+    case 'image':
+      return 'picture'
+    default:
+      return 'file'
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,6 +74,26 @@ export interface TaskWithDocuments extends Task {
   documents: DocumentWithImages[]
 }
 
+// Exactly what rendering a document's body needs — and deliberately nothing
+// more. No `file_path`, so no storage path travels to the browser for a
+// component that addresses everything through the proxy routes by id. Both
+// student surfaces satisfy it: the accordion passes its full
+// `DocumentWithImages` rows, the full-page route selects only these columns.
+export type RenderableDocument = Pick<Document, 'id' | 'title' | 'file_type' | 'content'> & {
+  document_images: Pick<DocumentImage, 'id'>[]
+}
+
+// A single Document plus the ancestry its full-page route needs (#69):
+// `kurs.published` is what the page enforces access with, and the ids and
+// titles are the way back into the hierarchy for someone who arrived from a
+// bookmark or a shared link with no history behind them.
+export interface DocumentWithAncestry {
+  document: RenderableDocument & Pick<Document, 'description'>
+  task: Pick<Task, 'id' | 'title'>
+  unit: Pick<Unit, 'id' | 'title'>
+  kurs: Pick<Kurs, 'id' | 'title' | 'published'>
+}
+
 export interface UnitWithTasks extends Unit {
   tasks: TaskWithDocuments[]
 }


### PR DESCRIPTION
## Summary

- Adds `/dokumente/[docId]` — the addressable full-page view a student can bookmark or send to a classmate. Nothing linked to a document before this; the segment is flat on purpose, because a link stores its target's document id and nothing else (#63 §6) and a top-level segment is the shape the overlay's intercepting route needs next (#70).
- **Access reuses the two mechanisms that already exist and adds none.** RLS on `documents` already requires an entitlement for the owning Unit (or admin), so an unentitled visitor's query returns no row; on top of that `kurse.published` is re-checked in app code with an admin bypass, exactly as `/api/file` does — that re-check, not RLS, is what makes an archived Kurs dark.
- Unknown id, missing entitlement and archived Kurs all land on the same 404. Distinguishing them would leak which documents exist to someone who cannot read them; telling a student which Einheit to unlock is a separate server-side surface (#74).
- The Unit accordion's four-way render branch moved into the shared `DocumentBody`, so a new node type or a changed fallback now lands on both surfaces or on neither. It branches on `documentViewKind` — a pure, tested seam. Accordion behaviour is unchanged; each document gains an „Einzelansicht ↗" link, without which the new URL would be unreachable from the app.
- The query selects no `file_path`: both renderers address the file and every image through the proxy routes by id, so no storage path travels to the browser. `RenderableDocument` is that narrowed shape.

## Test plan

- `npm run lint` — clean
- `npm test` — 439 tests / 12 files pass, including the new `document-view.test.ts` cases for the render-path seam
- `npm run build` — passes; `/dokumente/[docId]` appears in the route table
- Manual QA (no component or E2E seam in this repo):
  - interactive, image, image_collection and pdf documents each open at `/dokumente/<id>` and render as they do in the accordion
  - an entitled user can paste and bookmark the URL; the tab carries the document title
  - a document in an unpublished Kurs 404s for a student, opens for an admin
  - an unknown id 404s rather than erroring
  - „Einzelansicht ↗" opens the document; ← returns to the Unit with the right task expanded

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
