### PR TITLE
Link chips render and navigate in the student viewer (#73) + QA fixes #98–#101

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ yarn-error.log*
 .agents/
 skills-lock.json
 
+# playwright mcp scratch (snapshots, console logs, screenshots from manual QA)
+.playwright-mcp/
+
 # MCP server config (project-scoped, may contain sensitive URLs)
 .mcp.json
 

--- a/DEVELOPER_OVERVIEW.md
+++ b/DEVELOPER_OVERVIEW.md
@@ -127,6 +127,8 @@ src/
 │   │   ├── page.tsx               #   full-page view: loadDocumentSurface → DocumentArticle
 │   │   ├── error.tsx
 │   │   └── loading.tsx
+│   ├── einheiten/[unitId]/        # Flat Einheit URL (#73) — a REDIRECT to /kurse/[kursId]/units/[unitId]
+│   │   └── page.tsx               #   supplies the Kurs an Einheit link never stored; RLS decides 404 vs redirect
 │   ├── @modal/                    # Overlay slot (#70) — parallel route on the ROOT layout
 │   │   ├── default.tsx            #   renders null: what every non-intercepted route falls back to (its absence would 404 them)
 │   │   └── (.)dokumente/[docId]/  #   INTERCEPTS the route above on client-side navigation only
@@ -193,6 +195,7 @@ src/
 │   ├── document-view.ts           # documentViewKind(): which render path a Document takes (interactive | picture | collection | file) — pure, shared by both student surfaces
 │   ├── document-access.ts         # isDocumentReadable(): the one app-level access rule (published re-check + admin bypass, nullable view) — pure, tested
 │   ├── document-surface.ts        # loadDocumentSurface(): auth + DAL read + access rule + watermark, `cache`d — the single read path behind BOTH student document surfaces
+│   ├── link-navigation.ts         # linkHref()/linkOpensOverlay() (#73): a stored link target → a URL, and whether following it opens the overlay. Pure; injected into the renderer so lib/editor never learns this app's routes
 │   ├── schemas.ts                 # Zod schemas for server action input validation
 │   ├── audit.ts                   # logAdminAction() — fire-and-forget audit log writer
 │   ├── editor/                    # LaTeX editor (PRD #28): TWO imperative surfaces (controller.ts for /admin/editor, document-render.ts for the student viewer) + pure modules
@@ -200,8 +203,8 @@ src/
 │   │   ├── document-json.ts       # Versioned Zod schema (discriminated union over `version`: v1.0, v1.1 = block `anchor` + inline `link`) + ported importer + serializer. The inline vocabulary is built PER VERSION, so a v1.0 snapshot carrying a link is refused rather than duck-typed
 │   │   ├── document-version.ts    # Upgrade-on-read: pure vN→vN+1 chain + readDocumentJson (the boundary for stored snapshots) — pure
 │   │   ├── anchors.ts             # Sprungmarken (#71): the anchor's Zod shape + its block-dataset contract + the registry that resolves ids duplicated by copy/paste. DOM-only (no MathJax, no server), so jsdom-testable — but it WRITES block datasets and remembers who owns which id, so not pure
-│   │   ├── links.ts               # Cross-document links (#72): the target union ({kursId}|{unitId}|{docId}|{docId,anchorId}), the v1.1 `link` node's Zod shape, the chip's DOM contract, and the picker seam types. DOM-only, no server
-│   │   ├── document-render.ts     # Student renderer: document JSON → live DOM, reusing the importer + resolver; MathJax-free. Owns the student-editable inputs and the recompute they trigger, so it is imperative (owns its DOM, binds listeners) — React must not reconcile inside its container
+│   │   ├── links.ts               # Cross-document links (#72): the target union ({kursId}|{unitId}|{docId}|{docId,anchorId}), the v1.1 `link` node's Zod shape, the chip's DOM contract, the kind glyph/label a chip shows (#73), and the picker seam types. DOM-only, no server
+│   │   ├── document-render.ts     # Student renderer: document JSON → live DOM, reusing the importer + resolver; MathJax-free. Owns the student-editable inputs and the recompute they trigger, and swaps each authoring link chip for a navigable <a> (#73), so it is imperative (owns its DOM, binds listeners) — React must not reconcile inside its container
 │   │   ├── publish-plan.ts        # Copy-fresh-then-swap image re-homing plan for publishing (what to copy/rewrite/delete) — pure
 │   │   ├── expression-evaluator.ts # CSP-safe math tokenizer/parser — replaces new Function; errors → NaN
 │   │   ├── latex-normalise.ts     # LaTeX→expression translation + auto-expression extraction
@@ -320,9 +323,33 @@ The overlay is not cosmetic. **The viewer holds live student inputs and nothing 
 - **In-app document links carry `scroll={false}`** (that is all `DocumentLink` is for). Without it the router scrolls to the top of the "page" it is navigating to, silently throwing away the reading position of the page underneath.
 - **The dialog shell renders outside the Suspense boundary.** It costs no database read, so the overlay is on screen while the document is still loading — and it is the *same* dialog element before and after, which is what keeps focus where `showModal()` put it. A `loading.tsx` at that level would open one dialog and swap it for a second, moving focus mid-navigation.
 
+### Following a Link (#73)
+
+A link inside a document is stored as a target and a label; **turning that into a URL is app knowledge and lives in `lib/link-navigation.ts`**, injected into the student renderer as the `linkHref` adapter. The editor library therefore never learns this app's routes, and the renderer cannot silently disagree with `DocumentLink` about where a document lives.
+
+| Target | URL | Presentation |
+|--------|-----|--------------|
+| `{ kursId }` | `/kurse/[kursId]` | Ordinary navigation (a real departure) |
+| `{ unitId }` | `/einheiten/[unitId]` → redirect | Ordinary navigation |
+| `{ docId }` | `/dokumente/[docId]` | Overlay, `scroll: false` |
+| `{ docId, anchorId }` | `/dokumente/[docId]#anchorId` | Overlay, scrolled to the marked block |
+
+**`/einheiten/[unitId]` exists because of what a link stores.** An Einheit link carries `{ unitId }` alone while the Einheit is shown under its Kurs, so something must supply the Kurs id. One server-side redirect does it, which keeps the chip's href a pure function of the target — no lookup in the browser and no Kurs id copied into stored content where it could go stale. It adds no access surface: the lookup runs through the DAL under the reader's own RLS (`units` gate on `published`), and everything else is enforced by the Einheit page it hands the student to.
+
+**The chip is a real `<a href>`, built by `document-render.ts` in place of the authoring chip the importer produces.** That is what gives focus order, Enter, and „open in new tab" for free; a plain left click is intercepted and pushed through `router.push` so the source page is never unmounted, while a modified or middle click is left to the browser. `followLink` is handed the href the chip is **wearing**, not the target to re-resolve, so a click cannot travel somewhere other than where the chip says it goes. Without `followLink` the anchor still navigates — worse (typed values are lost), never dead.
+
+Two consequences of it being a raw anchor rather than a `next/link`, both accepted: **a chip does not prefetch** (`DocumentLink` does, which is why the accordion's „Einzelansicht" opens faster than a chip), and nothing about it can be reconciled by React — it lives in DOM the renderer owns.
+
+- **The kind glyph is CSS chrome**, drawn from `data-link-icon` via `attr()`, so it never enters the text a student copies. The one glyph map lives in `lib/editor/links.ts`; the chip's `aria-label` carries the same distinction in words for readers who get no icon.
+- **There is no hover behaviour anywhere, deliberately** (spec §6). The peek was dropped: the overlay does it better one click away with state intact, and a hover would make the product quietly different on touch. No preview, no prefetch on mouse-over, and no `title` tooltip.
+- **A Sprungmarke travels in the fragment**, never reaching the server, and is resolved against the rendered DOM after the first typeset run (formulas change height when MathJax replaces them). A `hashchange` listener covers a second jump inside a document already on screen.
+- Unreachable targets — locked, archived, deleted — are **#74's**: today a link to one lands on the same refusal any inaccessible document does.
+
 ### Error & Loading Boundaries
 
 Every major route segment has scoped `error.tsx` and `loading.tsx` files. A failed Supabase query shows a friendly German error UI instead of a white screen.
+
+**`app/einheiten/[unitId]` has neither**, deliberately: it renders nothing at all — one DAL read, then a `redirect()` or a `notFound()` — so a loading state would flash a boundary for a page that never appears, and a failed read falls through to the root `error.tsx` exactly as it should.
 
 **One deliberate exception:** the overlay slot `app/@modal/(.)dokumente/[docId]` has an `error.tsx` but **no `loading.tsx`** — its page streams the document into a `<Suspense>` inside the dialog it has already opened, and a segment-level loading boundary would open a second dialog and move focus mid-navigation. Both boundaries there render inside `DocumentOverlay` for the same reason: the page underneath is still mounted and the student needs the close button to get back to it.
 
@@ -371,7 +398,9 @@ All magic values live in `src/lib/constants.ts`:
 | `ALLOWED_FILE_MIMES` | `['application/pdf', ...]` | Accepted file types |
 | `MIME_TO_EXT` | `Record<string, string>` | MIME → file extension map |
 | `editorImageUrl(imageId)` | `` `/api/editor-image/${imageId}` `` | Single source for editor-image browser URLs (controller, JSON importer, proxy route) |
-| `documentUrl(docId)` | `` `/dokumente/${docId}` `` | Single source for the addressable Dokument URL (#69). In-app links go through `DocumentLink`, which adds the `scroll={false}` the overlay needs (#70) — the accordion's „Einzelansicht", `DocumentCard`, and every future link chip |
+| `documentUrl(docId, anchorId?)` | `` `/dokumente/${docId}` `` (+ `#anchorId`) | Single source for the addressable Dokument URL (#69). In-app links go through `DocumentLink`, which adds the `scroll={false}` the overlay needs (#70) — the accordion's „Einzelansicht", `DocumentCard`, and the link chips (#73) |
+| `kursUrl(kursId)` | `` `/kurse/${kursId}` `` | Where a Kurs link goes (#73) |
+| `unitUrl(unitId)` | `` `/einheiten/${unitId}` `` | Where an Einheit link goes (#73) — the flat redirect that supplies the Kurs a link never stored |
 
 ## Dependencies
 
@@ -421,7 +450,7 @@ npm run test:watch   # watch mode
 
 Conventions: tests are colocated `*.test.ts` files next to their modules and assert **external behavior only** (inputs → outputs, no internal call structure). The default environment is plain Node; DOM-dependent suites opt into jsdom per file via a `@vitest-environment jsdom` docblock — currently `document-json.test.ts`, whose importer builds real DOM. The editor-module tests under `src/lib/editor/` are golden cases generated from the standalone reference editor (`latexEditor/*.html`) and double as the React port's parity contract — expected values must not be changed without checking the reference behavior first.
 
-Tests are not confined to `src/lib/editor/`: any pure module is a candidate. `src/lib/document-view.test.ts` pins the render-path rule both student surfaces share and `src/lib/document-access.test.ts` pins the access rule they share. React components have no test seam here (no testing-library, no browser E2E) — component and navigation behaviour is verified by manual QA recorded on the ticket, which is why the overlay of #70 carries a written checklist rather than a suite.
+Tests are not confined to `src/lib/editor/`: any pure module is a candidate. `src/lib/document-view.test.ts` pins the render-path rule both student surfaces share, `src/lib/document-access.test.ts` pins the access rule they share, and `src/lib/link-navigation.test.ts` pins where a stored link target actually points (#73). React components have no test seam here (no testing-library, no browser E2E) — component and navigation behaviour is verified by manual QA recorded on the ticket, which is why the overlay of #70 carries a written checklist rather than a suite.
 
 ### Two Supabase Projects
 
@@ -516,6 +545,11 @@ Set `published = true/false` in the `kurse` table. The Kurs and its Units appear
 | A published Dokument lists no Sprungmarken | Legacy row, or an unreadable snapshot | Only `content` snapshots carry anchors: a PDF/image document has none, and a snapshot `readDocumentJson` refuses contributes none rather than failing the picker. The document itself stays linkable as a whole |
 | Can't put the cursor inside a link chip | By design (#72) | The chip is `contenteditable="false"` so no keystroke can separate a label from its target — **click** the chip to re-target, relabel or remove it |
 | „Link entfernen" leaves the words behind | By design (#72) | Unlinking replaces the chip with its own label as plain text; the author asked for the link to go, not the sentence |
+| A link chip in a published document is not clickable | The chip is still the authoring `<span>` — the renderer's swap did not run | Only `document-render.ts` turns a chip into an `<a href>`; check the document actually renders live (not the PNG fallback) and that the caller passes the `linkHref` adapter |
+| Following a link loses everything the student typed | The click was not intercepted, so the browser navigated | `followLink` must be wired (InteractiveDocument passes it) and the target must be a **Dokument** — a Kurs or Einheit link is a real departure and always unmounts the source |
+| A link chip shows no glyph | `data-link-icon` missing, or the `attr()` rule was scoped away | The glyph is CSS chrome (`interactive-document.css`) drawn from the attribute the renderer stamps; it is never part of the label |
+| An Einheit link 404s | Its Kurs or the Einheit itself is unpublished | `/einheiten/[unitId]` resolves through the DAL under the reader's RLS — no row, no redirect. Publish the Einheit, or accept the 404 as the archive rule working |
+| A link to a Sprungmarke opens the document at the top | The anchor id is not in that document's snapshot | The fragment is matched against `data-anchor-id` in the rendered DOM; a Sprungmarke deleted or re-stamped after the link was made no longer matches (that is #75's warning to add) |
 
 ## File Reference Guide
 
@@ -534,6 +568,7 @@ Set `published = true/false` in the `kurse` table. The Kurs and its Units appear
 | Student document rendering | `src/lib/document-view.ts`, `src/components/documents/DocumentBody.tsx`, `src/app/dokumente/[docId]/page.tsx` |
 | Student document access + shared page-scale view | `src/lib/document-access.ts`, `src/lib/document-surface.ts`, `src/components/documents/DocumentArticle.tsx` |
 | Document overlay navigation | `src/app/@modal/*`, `src/components/documents/DocumentOverlay.tsx`, `src/components/documents/DocumentLink.tsx`, `src/app/layout.tsx` |
+| Where a link goes | `src/lib/link-navigation.ts`, `src/app/einheiten/[unitId]/page.tsx`, `makeLinksNavigable` in `src/lib/editor/document-render.ts` |
 | LaTeX editor core (controller + pure modules) | `src/lib/editor/*` |
 | LaTeX editor UI (page, shell, toolbar, export, drafts) | `src/app/admin/editor/*`, `src/components/admin/editor/*` |
 | Standalone reference editor (parity ground truth) | `latexEditor/*.html` |

--- a/src/app/admin/editor/editor.css
+++ b/src/app/admin/editor/editor.css
@@ -500,21 +500,24 @@
    zählt — die Sprungmarke gewinnt gegen das allgemeine Dokument.
    ⚠ Zweite Kopie von LINK_KIND_ICON / LINK_ANCHOR_ICON (lib/editor/links.ts),
    den der Picker liest: ein ::before kann die Map nicht lesen, also müssen
-   beide Seiten gemeinsam geändert werden. */
+   beide Seiten gemeinsam geändert werden.
+   Das Trennzeichen ist ein geschütztes Leerzeichen (#100): sonst darf die Zeile
+   zwischen Symbol und Beschriftung umbrechen und das Symbol bleibt als eigener
+   leerer Chip zurück. Spiegelt interactive-document.css. */
 .latex-editor .doc-link[data-link-kind='kurs']::before {
-  content: '📘 ';
+  content: '📘\00a0';
 }
 
 .latex-editor .doc-link[data-link-kind='unit']::before {
-  content: '📗 ';
+  content: '📗\00a0';
 }
 
 .latex-editor .doc-link[data-link-kind='document']::before {
-  content: '📄 ';
+  content: '📄\00a0';
 }
 
 .latex-editor .doc-link[data-link-anchor-id]::before {
-  content: '⚓ ';
+  content: '⚓\00a0';
 }
 
 /* ------------------------------------------------- Sprungmarken (#71) */

--- a/src/app/einheiten/[unitId]/page.tsx
+++ b/src/app/einheiten/[unitId]/page.tsx
@@ -1,0 +1,31 @@
+import { notFound, redirect } from 'next/navigation'
+import { getUnitById } from '@/lib/dal'
+
+interface Props {
+  params: Promise<{ unitId: string }>
+}
+
+/**
+ * The flat URL of one Einheit (#73) — a redirect, and nothing else.
+ *
+ * IT EXISTS BECAUSE OF WHAT A LINK STORES. An Einheit link carries `{ unitId }`
+ * and nothing else (spec #63 §6), while the Einheit itself is shown at
+ * `/kurse/[kursId]/units/[unitId]`. Something has to supply the Kurs, and doing
+ * it here — one server-side primary-key read — keeps the link chip's href a
+ * pure function of the target, with no lookup in the browser and no Kurs id
+ * copied into stored content where it could go stale.
+ *
+ * NO NEW ACCESS SURFACE. The lookup goes through the DAL under the reader's own
+ * RLS, where `units` gate on `published`: an unpublished Einheit returns no row
+ * and lands on the same 404 an unknown id does. Everything the Einheit page
+ * itself enforces — entitlement, the paywall — is enforced there, unchanged,
+ * because this hands the student straight to it.
+ */
+export default async function EinheitLinkPage({ params }: Props) {
+  const { unitId } = await params
+
+  const unit = await getUnitById(unitId)
+  if (!unit) notFound()
+
+  redirect(`/kurse/${unit.kurs_id}/units/${unitId}`)
+}

--- a/src/components/documents/InteractiveDocument.tsx
+++ b/src/components/documents/InteractiveDocument.tsx
@@ -6,7 +6,7 @@ import { anchoredBlocks } from '@/lib/editor/anchors'
 import { renderDocumentJson } from '@/lib/editor/document-render'
 import { readDocumentJson } from '@/lib/editor/document-version'
 import { loadMathJax } from '@/lib/editor/mathjax-loader'
-import { linkHref, linkOpensOverlay } from '@/lib/link-navigation'
+import { documentIdInPath, linkHref, linkOpensOverlay } from '@/lib/link-navigation'
 import { DocumentPng } from './DocumentPng'
 import { Watermark } from './Watermark'
 import './interactive-document.css'
@@ -117,8 +117,7 @@ function LiveDocument({
     // typeset rather than straight after the render: a formula changes height
     // when its source is replaced by SVG, so scrolling before that settles
     // aims at a position the document is about to move out from under.
-    const scrollToMarkedSpot = () => {
-      const anchorId = markedSpotInUrl()
+    const scrollToMarkedSpot = (anchorId: string) => {
       if (!anchorId) return
       // Matched by walking the marked blocks rather than by a selector: an
       // anchor id is opaque and only ever required to be non-empty, so it
@@ -126,6 +125,24 @@ function LiveDocument({
       const block = anchoredBlocks(host).find((el) => el.dataset['anchorId'] === anchorId)
       block?.scrollIntoView({ block: 'start' })
     }
+
+    // Whether THIS mounted copy is the one the URL is addressing (#99).
+    //
+    // The Einheit page renders every document of the unit live at once, so
+    // opening the overlay on one of them puts the same `data-anchor-id` in the
+    // DOM twice. Both copies would otherwise chase the same fragment and the
+    // page underneath would scroll away behind the overlay — the one thing the
+    // overlay (#70) exists to prevent, and invisible until the student closes
+    // it and finds themselves somewhere else.
+    //
+    // Two conditions, both needed. The layer: a host's own dialog must be the
+    // open one, which with `null === null` also says that while no dialog is
+    // open only a host outside every dialog may move. And the address: the
+    // document the path names must be this one, which is what separates two
+    // different documents that happen to share an anchor id.
+    const addressesThisDocument = () =>
+      host.closest('dialog') === window.document.querySelector('dialog[open]') &&
+      documentIdInPath(window.location.pathname) === docId
 
     try {
       const { renderTargets } = renderDocumentJson(snapshot.doc, host, {
@@ -139,15 +156,38 @@ function LiveDocument({
         // `scroll: false` only for the overlay: it stops the router discarding
         // the reading position of a page that stays on screen, and would
         // strand a student halfway down a Kurs page they have never seen.
-        followLink: (target, href) =>
-          routerRef.current.push(href, { scroll: !linkOpensOverlay(target) }),
+        followLink: (target, href) => {
+          routerRef.current.push(href, { scroll: !linkOpensOverlay(target) })
+          // A Sprungmarke in the document ALREADY ON SCREEN moves nothing on
+          // its own (#98): that push differs from the current URL only in its
+          // fragment, so the router writes history with `pushState` — and
+          // `pushState` never fires `hashchange`. The listener below is never
+          // reached, which kills the most natural use of a Sprungmarke, a
+          // table of contents linking down into its own document. So resolve
+          // that case here instead of waiting for an event that never comes.
+          //
+          // The anchor comes off the target rather than out of the URL: it
+          // does not depend on when the router commits the push.
+          //
+          // Guarded exactly like the listener, and for the same reason. On the
+          // Einheit page this document is also rendered inline underneath, and
+          // a Dokument link there opens the overlay — so the copy that must
+          // scroll is the one the overlay is about to mount, never this one.
+          if (!('docId' in target) || target.docId !== docId || !target.anchorId) return
+          if (addressesThisDocument()) scrollToMarkedSpot(target.anchorId)
+        },
         // Only the formulas whose value actually moved — an untouched formula
         // must not re-typeset, and re-typesetting is what this costs.
         onRecompute: typeset,
       })
       typeset(renderTargets)
+      // Deliberately UNGUARDED, unlike the two paths above: this runs once per
+      // mount, so only the copy that was just created by the navigation can
+      // reach it. Asking `addressesThisDocument()` here would instead make the
+      // first jump depend on whether the overlay's `showModal()` has landed by
+      // the time the typeset queue drains.
       queue = queue.then(() => {
-        if (!cancelled) scrollToMarkedSpot()
+        if (!cancelled) scrollToMarkedSpot(markedSpotInUrl())
       })
     } catch (err) {
       // Leave nothing half-drawn behind before handing over to the picture.
@@ -161,15 +201,18 @@ function LiveDocument({
       })
     }
 
-    // A second link to another Sprungmarke in the document already on screen
-    // changes the fragment without remounting anything, so the jump has to be
-    // listened for. Every mounted document hears it and only the one actually
-    // holding that marked spot moves.
-    window.addEventListener('hashchange', scrollToMarkedSpot)
+    // What is left for `hashchange` is history traversal — Back and Forward
+    // between two fragment URLs, which no click adapter sees. Every mounted
+    // document hears it, so the copy the URL is not addressing has to say so
+    // itself; a marked spot can exist in more than one place at once.
+    const onHashChange = () => {
+      if (addressesThisDocument()) scrollToMarkedSpot(markedSpotInUrl())
+    }
+    window.addEventListener('hashchange', onHashChange)
 
     return () => {
       cancelled = true
-      window.removeEventListener('hashchange', scrollToMarkedSpot)
+      window.removeEventListener('hashchange', onHashChange)
     }
   }, [snapshot, docId])
 

--- a/src/components/documents/InteractiveDocument.tsx
+++ b/src/components/documents/InteractiveDocument.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import { Component, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useRouter } from 'next/navigation'
+import { anchoredBlocks } from '@/lib/editor/anchors'
 import { renderDocumentJson } from '@/lib/editor/document-render'
 import { readDocumentJson } from '@/lib/editor/document-version'
 import { loadMathJax } from '@/lib/editor/mathjax-loader'
+import { linkHref, linkOpensOverlay } from '@/lib/link-navigation'
 import { DocumentPng } from './DocumentPng'
 import { Watermark } from './Watermark'
 import './interactive-document.css'
@@ -73,6 +76,17 @@ function LiveDocument({
   const hostRef = useRef<HTMLDivElement | null>(null)
   const [renderFailed, setRenderFailed] = useState(false)
 
+  // The router is reached through a ref rather than through the effect's
+  // dependencies, and that is not a style choice: re-running the effect calls
+  // `renderDocumentJson` again, which rebuilds the whole document and throws
+  // away every value the student typed into it. Nothing that merely CHANGES may
+  // be a dependency of this effect.
+  const router = useRouter()
+  const routerRef = useRef(router)
+  useEffect(() => {
+    routerRef.current = router
+  }, [router])
+
   useEffect(() => {
     if (!snapshot.ok) {
       console.error(`[InteractiveDocument ${docId}] Snapshot abgelehnt, PNG-Fallback:`, snapshot.error)
@@ -99,14 +113,42 @@ function LiveDocument({
         })
     }
 
+    // Where a link lands inside THIS document (#73). Run after the first
+    // typeset rather than straight after the render: a formula changes height
+    // when its source is replaced by SVG, so scrolling before that settles
+    // aims at a position the document is about to move out from under.
+    const scrollToMarkedSpot = () => {
+      const anchorId = markedSpotInUrl()
+      if (!anchorId) return
+      // Matched by walking the marked blocks rather than by a selector: an
+      // anchor id is opaque and only ever required to be non-empty, so it
+      // cannot be interpolated into one safely.
+      const block = anchoredBlocks(host).find((el) => el.dataset['anchorId'] === anchorId)
+      block?.scrollIntoView({ block: 'start' })
+    }
+
     try {
       const { renderTargets } = renderDocumentJson(snapshot.doc, host, {
         imageUrl: (imageId) => `/api/image/${imageId}`,
+        linkHref,
+        // Client-side, so the page underneath is never unmounted and the
+        // values the student typed survive the trip (#70). The href comes back
+        // from the chip rather than being resolved again, so a click cannot
+        // land anywhere other than where the chip says it goes.
+        //
+        // `scroll: false` only for the overlay: it stops the router discarding
+        // the reading position of a page that stays on screen, and would
+        // strand a student halfway down a Kurs page they have never seen.
+        followLink: (target, href) =>
+          routerRef.current.push(href, { scroll: !linkOpensOverlay(target) }),
         // Only the formulas whose value actually moved — an untouched formula
         // must not re-typeset, and re-typesetting is what this costs.
         onRecompute: typeset,
       })
       typeset(renderTargets)
+      queue = queue.then(() => {
+        if (!cancelled) scrollToMarkedSpot()
+      })
     } catch (err) {
       // Leave nothing half-drawn behind before handing over to the picture.
       host.replaceChildren()
@@ -119,8 +161,15 @@ function LiveDocument({
       })
     }
 
+    // A second link to another Sprungmarke in the document already on screen
+    // changes the fragment without remounting anything, so the jump has to be
+    // listened for. Every mounted document hears it and only the one actually
+    // holding that marked spot moves.
+    window.addEventListener('hashchange', scrollToMarkedSpot)
+
     return () => {
       cancelled = true
+      window.removeEventListener('hashchange', scrollToMarkedSpot)
     }
   }, [snapshot, docId])
 
@@ -132,6 +181,23 @@ function LiveDocument({
       <Watermark id={watermarkId} />
     </div>
   )
+}
+
+/**
+ * The Sprungmarke the current URL asks for, or `''`.
+ *
+ * A fragment is user-supplied text — a hand-typed or truncated URL can carry a
+ * broken escape sequence, and `decodeURIComponent` throws on those. Falling
+ * back to the raw fragment keeps a bad URL from throwing out of a listener over
+ * something as small as a scroll position.
+ */
+function markedSpotInUrl(): string {
+  const raw = window.location.hash.slice(1)
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    return raw
+  }
 }
 
 /**

--- a/src/components/documents/interactive-document.css
+++ b/src/components/documents/interactive-document.css
@@ -216,6 +216,60 @@
   box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.45);
 }
 
+/* ------------------------------------------------------------- Link-Chips */
+
+/*
+ * A link inside a sentence (#73). It reads as a word, not as a button: the
+ * label carries the meaning and the glyph says how far the link travels — a
+ * Kurs, an Einheit, a Dokument or a Sprungmarke inside one.
+ *
+ * THERE IS NO HOVER PREVIEW AND THERE IS NOT MEANT TO BE. The peek was dropped
+ * (spec §6): the overlay shows the target one click away with everything the
+ * student typed intact, so a hover would only make the product quietly
+ * different on a touch screen. The colour shift below is the ordinary
+ * this-is-clickable feedback, and it is all a pointer gets.
+ */
+.dokum-document .doc-link {
+  display: inline;
+  padding: 1px 7px;
+  margin: 0 1px;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3730a3;
+  border: 1px solid #c7d2fe;
+  font-weight: 500;
+  text-decoration: none;
+  /* Wraps at the end of a line like the words around it rather than pushing
+     the whole chip onto the next one. */
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  transition: background-color 0.12s ease;
+}
+
+.dokum-document .doc-link:hover {
+  background: #e0e7ff;
+}
+
+.dokum-document .doc-link:focus-visible {
+  outline: 2px solid #4338ca;
+  outline-offset: 2px;
+}
+
+/* The glyph is drawn from the attribute the renderer stamps (document-render,
+   `replaceWithLinkAnchor`), which reads the one map in lib/editor/links.ts. A
+   pseudo-element keeps it out of `textContent`, so a student copying the
+   sentence gets the words and not the emoji. */
+.dokum-document .doc-link::before {
+  content: attr(data-link-icon) ' ';
+}
+
+/* A Sprungmarke is where a link LANDS — the spot is scrolled to, so it must
+   not end up flush against the top edge, under the sticky header of either
+   surface that shows a document. */
+.dokum-document [data-anchor-id] {
+  scroll-margin-top: 4.5rem;
+}
+
 @media (max-width: 640px) {
   .dokum-document {
     font-size: 16px;

--- a/src/components/documents/interactive-document.css
+++ b/src/components/documents/interactive-document.css
@@ -37,6 +37,17 @@
   margin: 1em 0 0.4em;
 }
 
+/* Running text, and the only place a link chip can meet another one on the
+   line below. At 1.55 the line box is narrower than the 24px-tall chip (#101)
+   and two stacked pills touch, which reads as one dense block rather than two
+   separate targets — so the lines that can carry a chip get the room the chip
+   needs. A heading needs none of this: its line-height scales with its own
+   larger font and already clears the pill. */
+.dokum-document p,
+.dokum-document li {
+  line-height: 1.65;
+}
+
 .dokum-document p {
   margin: 0.8em 0;
 }
@@ -231,7 +242,11 @@
  */
 .dokum-document .doc-link {
   display: inline;
-  padding: 1px 7px;
+  /* 3px, not 1px, so the chip clears 24px tall — WCAG 2.2 AA 2.5.8, and a
+     thumb on a phone, where this is the only way to follow a link (#101).
+     `display: inline` means the extra padding overflows the line box instead
+     of pushing the lines apart, so paragraph rhythm is untouched. */
+  padding: 3px 7px;
   margin: 0 1px;
   border-radius: 999px;
   background: #eef2ff;
@@ -258,9 +273,15 @@
 /* The glyph is drawn from the attribute the renderer stamps (document-render,
    `replaceWithLinkAnchor`), which reads the one map in lib/editor/links.ts. A
    pseudo-element keeps it out of `textContent`, so a student copying the
-   sentence gets the words and not the emoji. */
+   sentence gets the words and not the emoji.
+
+   The separator is a NO-BREAK space (#100). With `box-decoration-break: clone`
+   an ordinary space lets the line break between glyph and label, and the glyph
+   is left behind as its own rounded pill — an empty chip that says nothing,
+   exactly where the reader needs to know how far the link travels. The label
+   itself still wraps freely. */
 .dokum-document .doc-link::before {
-  content: attr(data-link-icon) ' ';
+  content: attr(data-link-icon) '\00a0';
 }
 
 /* A Sprungmarke is where a link LANDS — the spot is scrolled to, so it must

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -34,6 +34,27 @@ export function editorImageUrl(imageId: string): string {
 // target's document id and nothing else (#63 §6), so the URL needs no Kurs or
 // Unit in it, and a top-level segment is also the shape the overlay's
 // intercepting route needs (#70).
-export function documentUrl(docId: string): string {
-  return `/dokumente/${docId}`
+//
+// `anchorId` puts a Sprungmarke in the fragment (#73). A fragment rather than a
+// query parameter because the spot inside a document is a client-side concern:
+// it never reaches the server, so neither route re-renders for it, and both the
+// full page and the overlay resolve it against the DOM they have already built.
+// It is percent-encoded because an anchor id is opaque — the schema asks only
+// that it be non-empty (anchors.ts).
+export function documentUrl(docId: string, anchorId?: string): string {
+  const base = `/dokumente/${docId}`
+  return anchorId ? `${base}#${encodeURIComponent(anchorId)}` : base
+}
+
+// The Kurs a link points at (#73) — the existing public Kurs page.
+export function kursUrl(kursId: string): string {
+  return `/kurse/${kursId}`
+}
+
+// The Einheit a link points at (#73), FLAT for the same reason `documentUrl`
+// is: a link stores `{ unitId }` and nothing else, while the Einheit page lives
+// under its Kurs. This URL is the redirect that supplies the missing half, so
+// following an Einheit link needs no client-side lookup of its Kurs.
+export function unitUrl(unitId: string): string {
+  return `/einheiten/${unitId}`
 }

--- a/src/lib/editor/document-render.test.ts
+++ b/src/lib/editor/document-render.test.ts
@@ -14,9 +14,23 @@
 
 import { describe, expect, it } from 'vitest'
 import type { LatestEditorDocumentJson } from './document-json'
-import { renderDocumentJson } from './document-render'
+import { renderDocumentJson, type DocumentRenderAdapters } from './document-render'
+import { linkTargetAnchorId, linkTargetId, type LinkTarget } from './links'
 
 const IMG_ID = '44444444-4444-4444-8444-444444444444'
+
+/**
+ * The two things the renderer refuses to know by itself. Both are stubs on
+ * purpose: a URL that looks nothing like the app's proves the chip is pointed
+ * by the caller rather than by a route baked into the renderer.
+ */
+const ADAPTERS: DocumentRenderAdapters = {
+  imageUrl: (id) => `/api/image/${id}`,
+  linkHref: (target) => {
+    const anchor = linkTargetAnchorId(target)
+    return `/ziel/${linkTargetId(target)}` + (anchor ? `#${anchor}` : '')
+  },
+}
 
 function mount(): HTMLElement {
   const host = document.createElement('div')
@@ -25,7 +39,7 @@ function mount(): HTMLElement {
 }
 
 function render(doc: LatestEditorDocumentJson, host = mount()) {
-  const result = renderDocumentJson(doc, host, { imageUrl: (id) => `/api/image/${id}` })
+  const result = renderDocumentJson(doc, host, ADAPTERS)
   return { host, result }
 }
 
@@ -369,7 +383,7 @@ describe('renderDocumentJson — live recompute', () => {
     const changed: HTMLElement[][] = []
     const host = mount()
     const { renderTargets } = renderDocumentJson(WORKED_EXAMPLE, host, {
-      imageUrl: (id) => `/api/image/${id}`,
+      ...ADAPTERS,
       onRecompute: (targets) => changed.push(targets),
     })
     expect(renderTargets[0]?.dataset['latex']).toContain('1 000')
@@ -397,7 +411,7 @@ describe('renderDocumentJson — live recompute', () => {
     const changed: HTMLElement[][] = []
     const host = mount()
     renderDocumentJson(doc, host, {
-      imageUrl: (id) => `/api/image/${id}`,
+      ...ADAPTERS,
       onRecompute: (targets) => changed.push(targets),
     })
     type(inputsFor(host, 'v_unbeteiligt')[0]!, '7')
@@ -545,7 +559,7 @@ describe('renderDocumentJson — live recompute', () => {
     const changed: HTMLElement[][] = []
     const host = mount()
     renderDocumentJson(WORKED_EXAMPLE, host, {
-      imageUrl: (id) => `/api/image/${id}`,
+      ...ADAPTERS,
       onRecompute: (targets) => changed.push(targets),
     })
     const kap = inputsFor(host, 'v_kap')[0]!
@@ -573,5 +587,145 @@ describe('renderDocumentJson — live recompute', () => {
     const { host } = render(WORKED_EXAMPLE)
     type(inputsFor(host, 'v_kap')[0]!, '9999')
     expect(JSON.stringify(WORKED_EXAMPLE)).toBe(before)
+  })
+})
+
+// ── Link chips (#73) ────────────────────────────────────────────────────────
+
+const KURS_ID = '11111111-1111-4111-8111-111111111111'
+const UNIT_ID = '22222222-2222-4222-8222-222222222222'
+const DOC_ID = '33333333-3333-4333-8333-333333333333'
+
+/** One link inside a sentence, which is the only place a link ever sits. */
+function withLink(target: LinkTarget, label = 'Kapitel 3'): LatestEditorDocumentJson {
+  return {
+    version: '1.1',
+    variables: [],
+    content: [
+      {
+        type: 'paragraph',
+        children: [{ text: 'Siehe ' }, { type: 'link', target, label }, { text: ' dazu.' }],
+      },
+    ],
+    library: [],
+  }
+}
+
+function chipIn(host: HTMLElement): HTMLAnchorElement {
+  const chip = host.querySelector<HTMLAnchorElement>('a.doc-link')
+  if (!chip) throw new Error('no link chip rendered')
+  return chip
+}
+
+/** A click the way a student makes it, or with a modifier held. */
+function click(el: HTMLElement, init: MouseEventInit = {}): MouseEvent {
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true, ...init })
+  el.dispatchEvent(event)
+  return event
+}
+
+describe('renderDocumentJson — link chips', () => {
+  it('renders a link as a labelled chip inside its sentence', () => {
+    const { host } = render(withLink({ docId: DOC_ID }))
+    expect(chipIn(host).textContent).toBe('Kapitel 3')
+    // The sentence still reads around it — a chip is a word, not a block.
+    expect(host.querySelector('p')?.textContent).toBe('Siehe Kapitel 3 dazu.')
+  })
+
+  it('points the chip wherever the caller resolves the target', () => {
+    const { host } = render(withLink({ unitId: UNIT_ID }))
+    expect(chipIn(host).getAttribute('href')).toBe(`/ziel/${UNIT_ID}`)
+  })
+
+  it('shows what kind of thing it points at, without putting it in the text', () => {
+    // The glyph is CSS chrome drawn from an attribute: it must not land in the
+    // text a student selects and copies out of the document.
+    const seen = new Set<string>()
+    for (const target of [
+      { kursId: KURS_ID },
+      { unitId: UNIT_ID },
+      { docId: DOC_ID },
+      { docId: DOC_ID, anchorId: 'anc_1' },
+    ] as const) {
+      const chip = chipIn(render(withLink(target)).host)
+      const icon = chip.dataset['linkIcon'] ?? ''
+      expect(icon).not.toBe('')
+      expect(chip.textContent).toBe('Kapitel 3')
+      seen.add(icon)
+    }
+    expect(seen.size).toBe(4)
+  })
+
+  it('names the target kind for a screen reader, which gets no glyph', () => {
+    expect(chipIn(render(withLink({ kursId: KURS_ID })).host).getAttribute('aria-label')).toBe(
+      'Kapitel 3 – Kurs'
+    )
+    expect(
+      chipIn(render(withLink({ docId: DOC_ID, anchorId: 'anc_1' })).host).getAttribute('aria-label')
+    ).toBe('Kapitel 3 – Sprungmarke')
+  })
+
+  it('is reachable and activatable from the keyboard', () => {
+    const { host } = render(withLink({ docId: DOC_ID }))
+    const chip = chipIn(host)
+    // A real anchor with a real href: focus, Enter and „open in new tab" all
+    // come from the platform rather than from a key handler of ours.
+    expect(chip.tagName).toBe('A')
+    expect(chip.hasAttribute('href')).toBe(true)
+    chip.focus()
+    expect(document.activeElement).toBe(chip)
+  })
+
+  it('carries no hover behaviour at all — touch and desktop are identical', () => {
+    const { host } = render(withLink({ docId: DOC_ID }))
+    const chip = chipIn(host)
+    // A `title` would be a tooltip, which is exactly the dropped peek.
+    expect(chip.hasAttribute('title')).toBe(false)
+    expect(chip.getAttribute('target')).toBeNull()
+  })
+
+  it('follows a plain click through the app instead of reloading the page', () => {
+    const followed: Array<[LinkTarget, string]> = []
+    const host = mount()
+    renderDocumentJson(withLink({ docId: DOC_ID, anchorId: 'anc_1' }), host, {
+      ...ADAPTERS,
+      followLink: (target, href) => followed.push([target, href]),
+    })
+    const chip = chipIn(host)
+    const event = click(chip)
+    // Followed to exactly where the chip says it goes — resolving the target a
+    // second time is how a click and its own href drift apart.
+    expect(followed).toEqual([[{ docId: DOC_ID, anchorId: 'anc_1' }, chip.getAttribute('href')]])
+    // Prevented, or the browser would navigate as well and unmount the page
+    // holding everything the student typed.
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('leaves a modified or middle click to the browser', () => {
+    const followed: LinkTarget[] = []
+    const host = mount()
+    renderDocumentJson(withLink({ docId: DOC_ID }), host, {
+      ...ADAPTERS,
+      followLink: (target) => followed.push(target),
+    })
+    const chip = chipIn(host)
+    for (const init of [{ ctrlKey: true }, { metaKey: true }, { shiftKey: true }, { button: 1 }]) {
+      expect(click(chip, init).defaultPrevented).toBe(false)
+    }
+    expect(followed).toEqual([])
+  })
+
+  it('still navigates when nobody is listening — a chip is never dead', () => {
+    const { host } = render(withLink({ docId: DOC_ID }))
+    // No `followLink`: the anchor's own href takes over, which is a worse
+    // navigation (the source page unmounts) but never a broken one.
+    expect(click(chipIn(host)).defaultPrevented).toBe(false)
+    expect(chipIn(host).getAttribute('href')).toBe(`/ziel/${DOC_ID}`)
+  })
+
+  it('leaves a document without links exactly as it was', () => {
+    const { host } = render(DOC)
+    expect(host.querySelector('.doc-link')).toBeNull()
+    expect(host.querySelector('a')).toBeNull()
   })
 })

--- a/src/lib/editor/document-render.ts
+++ b/src/lib/editor/document-render.ts
@@ -72,6 +72,14 @@ import {
   type FieldGraph,
   type LineToken,
 } from './field-resolver'
+import {
+  LINK_CHIP_SELECTOR,
+  linkTargetIcon,
+  linkTargetKindLabel,
+  readLinkChip,
+  type DocumentLink,
+  type LinkTarget,
+} from './links'
 import { formatGermanEntry, formatValue, parseGermanEntry } from './number-format'
 
 export interface DocumentRenderAdapters {
@@ -82,6 +90,29 @@ export interface DocumentRenderAdapters {
    * needed.
    */
   imageUrl(imageId: string): string
+  /**
+   * Browser URL for a link target (#73). REQUIRED, not optional: a chip with no
+   * href is a dead end in the middle of a sentence, and making it optional
+   * would let a surface ship one by forgetting a line. Where a link goes is app
+   * knowledge, so it is injected rather than derived here.
+   */
+  linkHref(target: LinkTarget): string
+  /**
+   * Follows a link WITHOUT leaving the page, when the caller can (#73). It
+   * exists because the student's typed values live only in this DOM: a real
+   * navigation unmounts the source document and takes them with it, while a
+   * client-side one opens the target as an overlay over a page that stays
+   * mounted (#70).
+   *
+   * It is handed the href the chip is actually WEARING rather than resolving
+   * the target a second time, so a click can never travel somewhere other than
+   * where the chip says it goes.
+   *
+   * Optional, and its absence is a real fallback rather than a broken state —
+   * the chip is a genuine `<a href>`, so the browser navigates on its own. The
+   * student loses what they typed, which is worse, but nothing is dead.
+   */
+  followLink?(target: LinkTarget, href: string): void
   /**
    * Called after a student edit has been resolved through the whole document
    * (#68), with the formula elements whose LaTeX actually changed — usually a
@@ -133,6 +164,7 @@ export function renderDocumentJson(
   // it by class and never descends into it, and the graph reads only its
   // dataset — so span or input makes no difference to any resolved value.
   makeInputsEditable(container, graph, renderTargets, adapters)
+  makeLinksNavigable(container, adapters)
 
   resolveDocument(container, graph, renderTargets, { writeFormulaText: true })
 
@@ -386,6 +418,87 @@ function controlSize(value: string): number {
 /** A field rendered as the student's editable control rather than as a pill. */
 function isStudentControl(el: HTMLElement): el is HTMLInputElement {
   return el.tagName === 'INPUT' && el.classList.contains('student-input')
+}
+
+// ── Link chips (#73) ────────────────────────────────────────────────────────
+
+/**
+ * Turns every link the author placed into one a student can follow. The
+ * importer builds the same opaque `contenteditable="false"` span the editor
+ * uses — right for a surface where a link is a thing to re-target, wrong for
+ * one where it is a thing to travel through.
+ *
+ * So a chip becomes a real `<a href>`, the same swap {@link replaceWithControl}
+ * makes for inputs and for the same reason: the platform then supplies what
+ * would otherwise be a hand-rolled key handler — focus order, activation by
+ * Enter, „open in new tab", and the browser's own navigation when nothing
+ * intercepts the click.
+ *
+ * WHAT IS DELIBERATELY ABSENT IS HOVER. Nothing previews, nothing prefetches on
+ * mouse-over, no `title` tooltip: the peek was dropped (spec §6) because the
+ * overlay does it better one click away, and a hover would make the product
+ * quietly different on a touch screen. The label plus the kind glyph is the
+ * whole of "say where you go before I click".
+ */
+function makeLinksNavigable(container: HTMLElement, adapters: DocumentRenderAdapters): void {
+  for (const chip of Array.from(container.querySelectorAll<HTMLElement>(LINK_CHIP_SELECTOR))) {
+    const link = readLinkChip(chip)
+    // Not reachable through the importer, which only builds a chip from a
+    // parsed link node. Left exactly as it is rather than guessed at: the
+    // words stay in the sentence, unlinked.
+    if (!link) continue
+
+    const href = adapters.linkHref(link.target)
+    const anchor = replaceWithLinkAnchor(chip, link, href)
+    // Per-element, like the input controls: they are rebuilt whenever the
+    // container is re-rendered, so their listeners die with them.
+    anchor.addEventListener('click', (event) => {
+      const follow = adapters.followLink
+      if (!follow || !isPlainLeftClick(event)) return
+      // Without this the browser navigates as well, unmounting the document
+      // and everything the student typed into it.
+      event.preventDefault()
+      follow(link.target, href)
+    })
+  }
+}
+
+/** Swaps an authoring chip for the student's navigable one. */
+function replaceWithLinkAnchor(
+  chip: HTMLElement,
+  link: DocumentLink,
+  href: string
+): HTMLAnchorElement {
+  const anchor = chip.ownerDocument.createElement('a')
+  // Copy every attribute wholesale, as the input control does: `data-link-*` is
+  // the chip's identity, `class` is what the stylesheet matches, and a key
+  // added to the link node later travels with them. The editor-only
+  // `contenteditable` rides along and is taken off by `stripEditorChrome`,
+  // which is where every such attribute goes.
+  for (const attr of Array.from(chip.attributes)) anchor.setAttribute(attr.name, attr.value)
+  anchor.setAttribute('href', href)
+  // The glyph is drawn by CSS from this attribute rather than written into the
+  // chip, so it never lands in the text a student selects and copies out — the
+  // same rule the authoring chip follows, reading the same map.
+  anchor.dataset['linkIcon'] = linkTargetIcon(link.target)
+  // Which means a screen reader would get nothing at all from it. This is how
+  // "what kind of thing does this point at" reaches a reader who cannot see the
+  // icon (spec §6, user story 19).
+  anchor.setAttribute('aria-label', `${link.label} – ${linkTargetKindLabel(link.target)}`)
+  anchor.textContent = link.label
+  chip.replaceWith(anchor)
+  return anchor
+}
+
+/**
+ * A click the app should handle itself. Everything else — a modifier held, the
+ * middle button — is the student asking the BROWSER for something (a new tab, a
+ * new window), and intercepting it would take that away.
+ */
+function isPlainLeftClick(event: MouseEvent): boolean {
+  return (
+    event.button === 0 && !event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey
+  )
 }
 
 // ── Field graph over the rendered DOM ───────────────────────────────────────

--- a/src/lib/editor/links.test.ts
+++ b/src/lib/editor/links.test.ts
@@ -18,8 +18,10 @@ import {
   LinkTargetSchema,
   createLinkChip,
   linkTargetAnchorId,
+  linkTargetIcon,
   linkTargetId,
   linkTargetKind,
+  linkTargetKindLabel,
   readLinkChip,
   sameLinkTarget,
   writeLinkChip,
@@ -176,4 +178,28 @@ describe('link chip dataset', () => {
     expect(readLinkChip(el)).toBeNull()
   })
 
+})
+
+// ── What a chip says about its target (#73) ─────────────────────────────────
+
+describe('how far a link travels', () => {
+  it('gives each kind its own glyph, and a Sprungmarke its own', () => {
+    const glyphs = [
+      linkTargetIcon({ kursId: KURS_ID }),
+      linkTargetIcon({ unitId: UNIT_ID }),
+      linkTargetIcon({ docId: DOC_ID }),
+      linkTargetIcon({ docId: DOC_ID, anchorId: 'anc_1' }),
+    ]
+    expect(new Set(glyphs).size).toBe(4)
+    expect(glyphs.every((g) => g.length > 0)).toBe(true)
+  })
+
+  it('names the target in German for the readers who get no glyph', () => {
+    // The glyph is CSS chrome so it never reaches a screen reader; this is what
+    // does, and it has to draw the same four distinctions.
+    expect(linkTargetKindLabel({ kursId: KURS_ID })).toBe('Kurs')
+    expect(linkTargetKindLabel({ unitId: UNIT_ID })).toBe('Einheit')
+    expect(linkTargetKindLabel({ docId: DOC_ID })).toBe('Dokument')
+    expect(linkTargetKindLabel({ docId: DOC_ID, anchorId: 'anc_1' })).toBe('Sprungmarke')
+  })
 })

--- a/src/lib/editor/links.ts
+++ b/src/lib/editor/links.ts
@@ -119,13 +119,14 @@ export const LINK_KIND_LABEL: Record<LinkTargetKind, string> = {
 }
 
 /**
- * The glyph that tells an author how far a link travels, one per kind.
+ * The glyph that tells a reader how far a link travels, one per kind.
  *
- * ⚠ MIRRORED IN CSS. The chip draws its own icon from `data-link-kind` in a
- * `::before` (editor.css, „Link-Chips"), because an icon inside the chip's text
- * would end up baked into a stored label. A pseudo-element cannot read this
- * map, so the two must be changed together — the picker reads it from here so
- * that at least the TypeScript side has one copy.
+ * ⚠ MIRRORED IN THE EDITOR'S CSS. The authoring chip draws its icon from
+ * `data-link-kind` in a `::before` (editor.css, „Link-Chips"), because an icon
+ * inside the chip's text would end up baked into a stored label. A
+ * pseudo-element cannot read this map, so those two must be changed together.
+ * The picker and the student's chip (#73) both read it from here, so the
+ * editor stylesheet is the only copy.
  */
 export const LINK_KIND_ICON: Record<LinkTargetKind, string> = {
   kurs: '📘',
@@ -135,6 +136,28 @@ export const LINK_KIND_ICON: Record<LinkTargetKind, string> = {
 
 /** A Sprungmarke is not a kind of its own, but it does get its own glyph. */
 export const LINK_ANCHOR_ICON = '⚓'
+
+/** …and its own name, for the same reason (#73). */
+export const LINK_ANCHOR_LABEL = 'Sprungmarke'
+
+/**
+ * The glyph a target wears. A Sprungmarke wins over the document that holds it
+ * — it is the more specific thing, and it is the one that says the link lands
+ * somewhere particular rather than at the top.
+ */
+export function linkTargetIcon(target: LinkTarget): string {
+  if (linkTargetAnchorId(target)) return LINK_ANCHOR_ICON
+  return LINK_KIND_ICON[linkTargetKind(target)]
+}
+
+/**
+ * What the glyph would say in words — the same four distinctions, for the
+ * readers a CSS-drawn icon never reaches (#73, spec §6 user story 19).
+ */
+export function linkTargetKindLabel(target: LinkTarget): string {
+  if (linkTargetAnchorId(target)) return LINK_ANCHOR_LABEL
+  return LINK_KIND_LABEL[linkTargetKind(target)]
+}
 
 /** The class every link chip carries — the serializer's hook. */
 export const LINK_CHIP_CLASS = 'doc-link'

--- a/src/lib/link-navigation.test.ts
+++ b/src/lib/link-navigation.test.ts
@@ -1,0 +1,59 @@
+/**
+ * link-navigation tests (#73).
+ *
+ * Behavioural: given what a link STORES, where does the browser go? The two
+ * interesting cases are the ones the stored target cannot answer on its own —
+ * an Einheit whose Kurs the link never recorded, and a spot inside a document.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { linkHref, linkOpensOverlay } from './link-navigation'
+
+const KURS_ID = '11111111-1111-4111-8111-111111111111'
+const UNIT_ID = '22222222-2222-4222-8222-222222222222'
+const DOC_ID = '33333333-3333-4333-8333-333333333333'
+
+describe('linkHref', () => {
+  it('sends a Kurs link to that Kurs', () => {
+    expect(linkHref({ kursId: KURS_ID })).toBe(`/kurse/${KURS_ID}`)
+  })
+
+  it('sends an Einheit link to a URL that needs no Kurs id', () => {
+    // A link stores `{ unitId }` and nothing else (spec §6), while the Einheit
+    // page lives under its Kurs — so the flat URL is what makes an Einheit
+    // link followable at all.
+    expect(linkHref({ unitId: UNIT_ID })).toBe(`/einheiten/${UNIT_ID}`)
+  })
+
+  it('sends a Dokument link to the addressable document URL', () => {
+    expect(linkHref({ docId: DOC_ID })).toBe(`/dokumente/${DOC_ID}`)
+  })
+
+  it('carries a Sprungmarke as the fragment, so the spot travels with the URL', () => {
+    expect(linkHref({ docId: DOC_ID, anchorId: 'anc_x1_2' })).toBe(
+      `/dokumente/${DOC_ID}#anc_x1_2`
+    )
+  })
+
+  it('encodes a Sprungmarke id that is not URL-safe', () => {
+    // Anchor ids are opaque and only ever `min(1)` in the schema, so a
+    // hand-authored or imported snapshot may hold anything at all.
+    expect(linkHref({ docId: DOC_ID, anchorId: 'a b#c' })).toBe(
+      `/dokumente/${DOC_ID}#a%20b%23c`
+    )
+  })
+})
+
+describe('linkOpensOverlay', () => {
+  it('is true for a Dokument, with or without a Sprungmarke', () => {
+    // Only a document has an intercepting route, so only a document can open
+    // on top of the page holding what the student typed.
+    expect(linkOpensOverlay({ docId: DOC_ID })).toBe(true)
+    expect(linkOpensOverlay({ docId: DOC_ID, anchorId: 'anc_1' })).toBe(true)
+  })
+
+  it('is false for a Kurs or an Einheit — those are real departures', () => {
+    expect(linkOpensOverlay({ kursId: KURS_ID })).toBe(false)
+    expect(linkOpensOverlay({ unitId: UNIT_ID })).toBe(false)
+  })
+})

--- a/src/lib/link-navigation.test.ts
+++ b/src/lib/link-navigation.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { linkHref, linkOpensOverlay } from './link-navigation'
+import { documentIdInPath, linkHref, linkOpensOverlay } from './link-navigation'
 
 const KURS_ID = '11111111-1111-4111-8111-111111111111'
 const UNIT_ID = '22222222-2222-4222-8222-222222222222'
@@ -55,5 +55,39 @@ describe('linkOpensOverlay', () => {
   it('is false for a Kurs or an Einheit — those are real departures', () => {
     expect(linkOpensOverlay({ kursId: KURS_ID })).toBe(false)
     expect(linkOpensOverlay({ unitId: UNIT_ID })).toBe(false)
+  })
+})
+
+describe('documentIdInPath', () => {
+  it('names the document a Dokument path addresses', () => {
+    expect(documentIdInPath(`/dokumente/${DOC_ID}`)).toBe(DOC_ID)
+  })
+
+  it('round-trips what linkHref produced, fragment and all', () => {
+    // The two halves must agree, or a chip could point at a document that then
+    // refuses to recognise itself as the addressed one.
+    const href = linkHref({ docId: DOC_ID, anchorId: 'anc_x1_2' })
+    expect(documentIdInPath(new URL(href, 'https://x').pathname)).toBe(DOC_ID)
+    expect(documentIdInPath(`/dokumente/${DOC_ID}#anc_x1_2`)).toBe(DOC_ID)
+  })
+
+  it('names no document for a Kurs or an Einheit path', () => {
+    // This is what keeps the copies rendered inline on an Einheit page still
+    // while the overlay above them takes the jump (#99).
+    expect(documentIdInPath(`/kurse/${KURS_ID}`)).toBeNull()
+    expect(documentIdInPath(`/kurse/${KURS_ID}/units/${UNIT_ID}`)).toBeNull()
+    expect(documentIdInPath(`/einheiten/${UNIT_ID}`)).toBeNull()
+    expect(documentIdInPath('/')).toBeNull()
+  })
+
+  it('does not mistake a longer path that merely starts the same way', () => {
+    expect(documentIdInPath('/dokumente')).toBeNull()
+    expect(documentIdInPath('/dokumente/')).toBeNull()
+    expect(documentIdInPath(`/dokumente/${DOC_ID}/etwas`)).toBe(DOC_ID)
+  })
+
+  it('survives a percent sequence it cannot decode', () => {
+    // A hand-typed or truncated URL must not throw out of a scroll decision.
+    expect(documentIdInPath('/dokumente/%E0%A4%A')).toBe('%E0%A4%A')
   })
 })

--- a/src/lib/link-navigation.ts
+++ b/src/lib/link-navigation.ts
@@ -45,3 +45,28 @@ export function linkHref(target: LinkTarget): string {
 export function linkOpensOverlay(target: LinkTarget): boolean {
   return 'docId' in target
 }
+
+/**
+ * The Dokument a browser path names, or `null` where it names none — the
+ * inverse of the `documentUrl` half of `linkHref`.
+ *
+ * Which mounted document may react to a fragment depends on this (#99): the
+ * Einheit page renders every document of its unit live at once, so opening the
+ * overlay puts the same Sprungmarke in the DOM twice, and a copy the URL is not
+ * addressing must sit still rather than scroll the page out from under the
+ * student. An Einheit or Kurs path names no document, which is exactly what
+ * silences those inline copies.
+ *
+ * The intercepted overlay route resolves to the same flat path as the full
+ * page, and that is deliberate: both are addressing that one document, and
+ * which of the two is on screen is a question about the DOM, not the URL.
+ */
+export function documentIdInPath(pathname: string): string | null {
+  const match = /^\/dokumente\/([^/?#]+)/.exec(pathname)
+  if (!match) return null
+  try {
+    return decodeURIComponent(match[1]!)
+  } catch {
+    return match[1]!
+  }
+}

--- a/src/lib/link-navigation.ts
+++ b/src/lib/link-navigation.ts
@@ -1,0 +1,47 @@
+/**
+ * link-navigation — where a stored link actually goes (#73, spec #63 §5/§6).
+ *
+ * A link stores a published primary key and nothing else. Turning that into a
+ * URL is app knowledge, not editor knowledge, which is why it lives here rather
+ * than in `lib/editor/links.ts`: the editor modules stay ignorant of this app's
+ * routes, and the student renderer takes this function as an ADAPTER so the two
+ * layers never point at each other.
+ *
+ * Two of the four shapes need more than an id substitution:
+ *
+ * - **An Einheit** is stored as `{ unitId }`, but its page lives under its Kurs
+ *   (`/kurse/[kursId]/units/[unitId]`), and the link never recorded the Kurs.
+ *   The flat `/einheiten/[unitId]` route is the server-side half that fills it
+ *   in, so an Einheit link is followable without a client-side lookup.
+ * - **A Sprungmarke** is a spot inside a document, which no route can address —
+ *   it becomes the URL's fragment, resolved against the rendered DOM.
+ *
+ * Pure: a string in, a string out, no fetch and no auth. Whether the student
+ * may actually SEE what is at the other end is decided where it is read, and
+ * telling locked apart from gone is #74's resolver.
+ */
+
+import { kursUrl, documentUrl, unitUrl } from '@/lib/constants'
+import { linkTargetAnchorId, type LinkTarget } from '@/lib/editor/links'
+
+/** The browser URL a link chip points at. */
+export function linkHref(target: LinkTarget): string {
+  if ('kursId' in target) return kursUrl(target.kursId)
+  if ('unitId' in target) return unitUrl(target.unitId)
+  const anchorId = linkTargetAnchorId(target)
+  return anchorId ? documentUrl(target.docId, anchorId) : documentUrl(target.docId)
+}
+
+/**
+ * Whether following this target keeps the student where they are. Only a
+ * Dokument has an intercepting overlay route (#70); a Kurs or an Einheit is a
+ * page of its own and navigating to it is an ordinary, scroll-to-top departure.
+ *
+ * The distinction is not cosmetic: `scroll: false` is what stops the router
+ * throwing away the reading position of the page the overlay opens on top of,
+ * and applying it to a real navigation would land the student halfway down a
+ * page they have never seen.
+ */
+export function linkOpensOverlay(target: LinkTarget): boolean {
+  return 'docId' in target
+}


### PR DESCRIPTION
## Summary

- A published document's link chips are now **real `<a href>` elements**, swapped in by the student renderer in place of the editor's opaque `contenteditable="false"` span — so focus order, Enter and „open in new tab" come from the platform, not from a key handler of ours.
- A plain left click is **intercepted and pushed through the router**, so the source page is never unmounted and the values the student typed survive the trip (#70); a modified or middle click is left to the browser.
- **Where a link goes is app knowledge**: `lib/link-navigation.ts` owns it and the renderer takes it as an adapter, so `lib/editor` never learns this app's routes. `followLink` receives the href the chip is *wearing* rather than the target to re-resolve, so a click cannot travel somewhere other than where the chip says it goes.
- **`/einheiten/[unitId]` is new and was unavoidable**: an Einheit link stores `{ unitId }` alone while the Einheit lives under its Kurs, so one server-side redirect supplies the missing Kurs id. No new access surface — the read goes through the DAL under the reader's own RLS.
- **A Sprungmarke travels in the URL fragment**, resolved against the rendered DOM after the first typeset run (formulas change height when MathJax replaces them), with a `hashchange` listener for a second jump inside a document already on screen.
- **The kind glyph is CSS chrome** drawn from `data-link-icon`, so it never enters the text a student copies; `aria-label` carries the same four distinctions in words. **No hover behaviour anywhere** — no preview, no prefetch on mouse-over, no `title` (the peek was dropped in spec §6).

Unreachable targets — locked, archived, deleted — stay #74's; today such a link lands on the same refusal any inaccessible document does.

## Test plan

- `npm run lint` — clean.
- `npm test` — 543 passing across 16 files, including new jsdom coverage of chip rendering: label, href from the injected adapter, per-kind glyph kept out of `textContent`, `aria-label`, keyboard focusability, plain-vs-modified click, and that a document without links renders exactly as before.
- `npm run build` — compiled successfully; `/einheiten/[unitId]` present in the route manifest.
- `src/lib/link-navigation.test.ts` pins all four target shapes → URL, including a non-URL-safe anchor id.
- **Manual QA (not automated — this repo has no browser E2E seam):** a chip inside an overlay opening a further document, the Sprungmarke landing position under the sticky header on both surfaces, and the chip's tap target on a phone.

## QA fixes (#98–#101)

Four defects found in the manual QA above, fixed on this branch.

**#98 — a Sprungmarke link into the document already on screen never scrolled.** The router writes a fragment-only change with `pushState`, which fires no `hashchange`, so the listener that resolves the fragment was never reached. That kills the most natural use of a Sprungmarke: a table of contents linking down into its own document. `followLink` now resolves the same-document jump directly rather than waiting for an event the router does not emit.

**#99 — a fragment change scrolled every mounted copy.** The Einheit page renders all of its documents live at once, so opening the overlay puts the same `data-anchor-id` in the DOM twice, and history traversal between two fragments scrolled the page underneath — the one failure the overlay (#70) exists to prevent.

These two are one seam. The fix suggested in #98 on its own **reintroduces #99**: on an Einheit page a Dokument link opens the overlay while the source copy stays mounted below, so a bare `target.docId === docId` test scrolls exactly the copy that must sit still. Both paths therefore share one guard — a copy moves only when its layer is the addressed one (its own `<dialog>` is the open one) *and* the path names its document. The route-parsing half is `documentIdInPath` in `lib/link-navigation.ts`, beside the `linkHref` it inverts, where it has a real test seam that a client component does not.

The first jump is deliberately left unguarded: it runs once per mount, so only the copy the navigation just created can reach it, and testing the guard there would make it depend on whether `showModal()` has landed by the time the typeset queue drains.

**#100 — a wrapped chip left its icon behind as an empty pill.** With `box-decoration-break: clone` an ordinary space in the `::before` lets the line break between glyph and label. A no-break space forbids that one break and leaves the label wrapping freely. Changed in both mirrored stylesheets.

**#101 — the tap target was 21px tall,** under the WCAG 2.2 AA 2.5.8 minimum of 24px. `padding: 3px 7px` lifts it clear. That made pills on consecutive lines overlap by 0.4px, so running text gets the line-height the taller chip needs — the remedy #101 named, rather than shrinking the target again.

### QA of the fixes

Verified in the browser against dev at 390 × 844 and 1280 × 900:

| Case | Before | After |
| --- | --- | --- |
| Same-document Sprungmarke, full page | target stayed at `top: 4101` | `top: 72`, under the sticky header |
| Same-document jump inside the overlay | no movement | overlay `top: 174`, page underneath unmoved |
| Back / Forward between two fragments, overlay open over an Einheit page | page underneath scrolled 3822 → 6426 | `scrollY` 3724 throughout, overlay jumps correctly |
| Deep link + reload to a non-URL-safe anchor id | landed | still lands (`top: 72`) |
| Wrapped chips at 390px | 7 of 11 wrapping, first fragment 38px glyph-only | 2 of 11, zero glyph-only fragments |
| Chip height | 21px (390px) / 23px (1280px) | 25.2px / 26.8px |
| Stacked pills on consecutive lines | 0.4px overlap | 1.2px gap |

No horizontal overflow at either width; the only console error is an unrelated blocked browser-extension script.

Closes #73, #98, #99, #100, #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

