### PR TITLE
Unreachable link targets: resolver route, unlock card, quiet degradation (#74)

### DIFF
--- a/DEVELOPER_OVERVIEW.md
+++ b/DEVELOPER_OVERVIEW.md
@@ -52,7 +52,7 @@ Kurs (Course)
 - Proxy (`src/proxy.ts` — Next.js 16 renamed the `middleware` convention to `proxy`) protects `/admin/*` routes and API proxy routes
 - Admin pages do **not** duplicate the auth check — the proxy is the single enforcement point
 - File proxy routes (`/api/file`, `/api/image`) verify the document belongs to a published course before serving — unauthenticated or unpublished-content requests return 401/403 at the application layer
-- `/api/link-target` (#74) is the one route that reads *past* RLS, and answers only with a verdict — locked, archived, missing, ok — plus the Einheit an unlock would buy. Never content, never a storage path. See [Unreachable Link Targets](#unreachable-link-targets-74)
+- `/api/link-target` (#74) is the only **read** route that answers past RLS (the service-role client is otherwise used by the payment routes, `/api/checkout/success` and `/api/stripe/webhook`, to *write*). It returns a verdict — locked, archived, missing, ok — plus the Einheit an unlock would buy. Never content, never a storage path. See [Unreachable Link Targets](#unreachable-link-targets-74)
 - JWT includes role automatically — no extra DB queries needed
 - Role grants: `UPDATE auth.users SET raw_app_meta_data = ... WHERE email = '...'` (user must sign out/in to refresh JWT)
 

--- a/DEVELOPER_OVERVIEW.md
+++ b/DEVELOPER_OVERVIEW.md
@@ -52,6 +52,7 @@ Kurs (Course)
 - Proxy (`src/proxy.ts` — Next.js 16 renamed the `middleware` convention to `proxy`) protects `/admin/*` routes and API proxy routes
 - Admin pages do **not** duplicate the auth check — the proxy is the single enforcement point
 - File proxy routes (`/api/file`, `/api/image`) verify the document belongs to a published course before serving — unauthenticated or unpublished-content requests return 401/403 at the application layer
+- `/api/link-target` (#74) is the one route that reads *past* RLS, and answers only with a verdict — locked, archived, missing, ok — plus the Einheit an unlock would buy. Never content, never a storage path. See [Unreachable Link Targets](#unreachable-link-targets-74)
 - JWT includes role automatically — no extra DB queries needed
 - Role grants: `UPDATE auth.users SET raw_app_meta_data = ... WHERE email = '...'` (user must sign out/in to refresh JWT)
 
@@ -148,7 +149,8 @@ src/
 │   └── api/
 │       ├── file/[docId]/route.ts          # Auth-gated file proxy (PDFs/images)
 │       ├── image/[imageId]/route.ts       # Auth-gated image collection proxy
-│       └── editor-image/[imageId]/route.ts # Admin-only editor-image proxy (STREAMS, same-origin)
+│       ├── editor-image/[imageId]/route.ts # Admin-only editor-image proxy (STREAMS, same-origin)
+│       └── link-target/[kind]/[id]/route.ts # Link resolver (#74): ok | locked | archived | missing + the Einheit that unlocks it — never content
 ├── components/
 │   ├── admin/
 │   │   ├── KursForm.tsx           # Create/edit Kurs form
@@ -177,6 +179,7 @@ src/
 │   │   ├── DocumentArticle.tsx     # Breadcrumb + title + description + body at page scale — shared by the full page and the overlay, which differ only in their chrome
 │   │   ├── DocumentOverlay.tsx     # The overlay shell (#70): native <dialog>.showModal() for the focus trap, Escape and inert background; every dismissal is router.back()
 │   │   ├── DocumentLink.tsx        # The in-app link to a Dokument — carries scroll={false} so opening an overlay cannot discard the source page's reading position
+│   │   ├── LinkLockedCard.tsx      # What a link into unbought material opens (#74): the Einheit + its teaser + the unlock button, as UnitPaywall inside a <dialog> — in place, so nothing the student typed is unmounted
 │   │   ├── DocumentCard.tsx
 │   │   ├── InteractiveDocument.tsx # Live student render of a published document JSON + PNG fallback (error boundary); owns only the MathJax half — typesets the formulas each recompute reports as changed, serialised so a fast typist cannot land a stale one
 │   │   ├── DocumentPng.tsx        #   the stored picture: legacy 'image' render AND the interactive fallback
@@ -196,6 +199,8 @@ src/
 │   ├── document-access.ts         # isDocumentReadable(): the one app-level access rule (published re-check + admin bypass, nullable view) — pure, tested
 │   ├── document-surface.ts        # loadDocumentSurface(): auth + DAL read + access rule + watermark, `cache`d — the single read path behind BOTH student document surfaces
 │   ├── link-navigation.ts         # linkHref()/linkOpensOverlay() (#73): a stored link target → a URL, and whether following it opens the overlay. Pure; injected into the renderer so lib/editor never learns this app's routes
+│   ├── link-target-state.ts       # describeLinkTarget() (#74): the ok|locked|archived|missing verdict AND what may cross with it, in one function so a field cannot be attached to a verdict that must not carry it. Pure, tested; NOT server-only — the browser parses the same schema
+│   ├── unreachable-links.ts       # Browser half of #74: resolves each distinct target once, degrades archived/deleted chips to plain text, re-points locked ones at their Einheit. Fails open — an unresolved chip is left exactly as the renderer built it
 │   ├── schemas.ts                 # Zod schemas for server action input validation
 │   ├── audit.ts                   # logAdminAction() — fire-and-forget audit log writer
 │   ├── editor/                    # LaTeX editor (PRD #28): TWO imperative surfaces (controller.ts for /admin/editor, document-render.ts for the student viewer) + pure modules
@@ -242,6 +247,8 @@ if (!kurs) notFound()
 ```
 
 The DAL is marked `import 'server-only'` — importing it in a client component causes a build error. Sorting (position ASC, created_at ASC) is applied inside each DAL function.
+
+**One read bypasses RLS**, and it is the only one: `getLinkTargetOwnership()` uses the service-role client, because the link resolver (#74) has to tell an *unentitled* student which Einheit to buy — and that is exactly the row `documents` SELECT withholds from them. Three properties keep it safe and all three are in the function: it selects only the columns a refusal may name (no `content`, no `file_path`), it never learns who is asking (no user id, no role — so it cannot leak per-reader data), and its result must pass through `describeLinkTarget()` before crossing to the browser. It has exactly one caller.
 
 ### Server Action Result Type
 
@@ -315,6 +322,8 @@ Access reuses the two mechanisms that already exist and adds none. Both surfaces
 
 Every failure — unknown id, no entitlement, archived Kurs — collapses into one refusal; distinguishing them would leak which documents exist to someone who cannot read them. The full page turns that into `notFound()`, the overlay into a „nicht gefunden" panel inside the dialog.
 
+**These surfaces still collapse them, and that has not changed.** The link resolver (#74, below) tells the three apart, but only for a target somebody has already *linked to*, only as a verdict plus the Einheit that unlocks it, and never as content — see that section for why the difference has to exist at all.
+
 **One URL, two presentations (#70).** A **hard** navigation — pasted link, bookmark, reload, a mail from a classmate — renders the full page. A **client-side** navigation from inside the app is intercepted by `app/@modal/(.)dokumente/[docId]` and opens the same document as a modal dialog over the current page: centred panel on desktop, full-screen sheet on a phone. Nothing in our code chooses between them; the App Router's interception rule does, and it only fires on soft navigation.
 
 The overlay is not cosmetic. **The viewer holds live student inputs and nothing persists them** — plain navigation would discard whatever the student typed, on the way out and again on the way back. Parallel routing never unmounts the `children` slot, so the source page (accordion state, scroll position, every typed value) is still there underneath and is still there when the overlay closes. Three rules keep that true:
@@ -343,7 +352,28 @@ Two consequences of it being a raw anchor rather than a `next/link`, both accept
 - **The kind glyph is CSS chrome**, drawn from `data-link-icon` via `attr()`, so it never enters the text a student copies. The one glyph map lives in `lib/editor/links.ts`; the chip's `aria-label` carries the same distinction in words for readers who get no icon.
 - **There is no hover behaviour anywhere, deliberately** (spec §6). The peek was dropped: the overlay does it better one click away with state intact, and a hover would make the product quietly different on touch. No preview, no prefetch on mouse-over, and no `title` tooltip.
 - **A Sprungmarke travels in the fragment**, never reaching the server, and is resolved against the rendered DOM after the first typeset run (formulas change height when MathJax replaces them). A `hashchange` listener covers a second jump inside a document already on screen.
-- Unreachable targets — locked, archived, deleted — are **#74's**: today a link to one lands on the same refusal any inaccessible document does.
+
+### Unreachable Link Targets (#74)
+
+A stored link outlives what it points at: the Einheit may be unbought, the Kurs archived, the Dokument deleted. **`GET /api/link-target/[kind]/[id]` is the resolver that tells those apart**, and it exists because RLS cannot: `documents` SELECT is entitlement-gated, so an unentitled student's lookup returns *no row at all* and locked is indistinguishable from deleted in the browser — while „das liegt in Einheit 3, schalte sie frei" needs exactly the data the policy withholds from the reader we want to sell to.
+
+The route is a thin shell: authenticate (same requirement and same `app_metadata.role` bypass as the file proxies), one identity-free privileged read, one entitlement read *under the reader's own RLS*, then the pure decision in `lib/link-target-state.ts`:
+
+| Verdict | When | What crosses to the browser |
+|---------|------|-----------------------------|
+| `missing` | no such row | nothing but the verdict |
+| `archived` | exists, Kurs unpublished | nothing but the verdict |
+| `locked` | live, Einheit not bought | the target's title + the Einheit and its teaser |
+| `ok` | reachable — and everything that exists, for an admin | nothing but the verdict |
+
+**The order between them is load-bearing: `archived` beats `locked`.** An unentitled reader looking at a link into a retired Kurs must not be offered a €3 unlock for an Einheit that stays dark.
+
+The chips are resolved **eagerly**, one request per *distinct* target, after the document is already on screen — `DocumentRenderResult.links` reports them for exactly this, the same way `renderTargets` reports the formulas the renderer refuses to typeset. Then `lib/unreachable-links.ts` rewrites each one:
+
+- **archived / missing** → no longer a link. The author's words plus a quiet „(nicht mehr verfügbar)", so the sentence still reads. Both say the same thing — which of the two it is belongs to the operator.
+- **locked** → still a chip, now amber with a lock glyph. Its href is **re-pointed at the Einheit**, so a middle click, „open in new tab" or our JS not running all land on the paywall rather than a dead end; a plain click opens `LinkLockedCard` in place, which is `UnitPaywall` — the same component the locked Einheit page shows — so the teaser reaches both surfaces by construction.
+
+Two rules that are easy to break: **both rewrites replace the element** rather than mutating it, because the renderer bound a click listener that pushes the target's URL and there is no handle to remove it with — a mutated locked chip would still navigate to the refusal this replaces. And the whole path **fails open**: an unreachable resolver, a non-OK status, or a body that does not parse (what an unauthenticated fetch actually gets is the proxy's HTML login redirect) all leave every chip exactly as the renderer built it. A document must never silently unlink itself because a request failed.
 
 ### Error & Loading Boundaries
 
@@ -400,7 +430,8 @@ All magic values live in `src/lib/constants.ts`:
 | `editorImageUrl(imageId)` | `` `/api/editor-image/${imageId}` `` | Single source for editor-image browser URLs (controller, JSON importer, proxy route) |
 | `documentUrl(docId, anchorId?)` | `` `/dokumente/${docId}` `` (+ `#anchorId`) | Single source for the addressable Dokument URL (#69). In-app links go through `DocumentLink`, which adds the `scroll={false}` the overlay needs (#70) — the accordion's „Einzelansicht", `DocumentCard`, and the link chips (#73) |
 | `kursUrl(kursId)` | `` `/kurse/${kursId}` `` | Where a Kurs link goes (#73) |
-| `unitUrl(unitId)` | `` `/einheiten/${unitId}` `` | Where an Einheit link goes (#73) — the flat redirect that supplies the Kurs a link never stored |
+| `unitUrl(unitId)` | `` `/einheiten/${unitId}` `` | Where an Einheit link goes (#73) — the flat redirect that supplies the Kurs a link never stored. Also where a **locked** chip is re-pointed (#74), so every path out of it lands on the paywall rather than a dead end |
+| `linkTargetUrl(kind, id)` | `` `/api/link-target/${kind}/${id}` `` | The resolver a rendered chip asks whether its target is still reachable (#74). The id is percent-encoded — it is read off a chip's dataset in the browser |
 
 ## Dependencies
 
@@ -550,6 +581,10 @@ Set `published = true/false` in the `kurse` table. The Kurs and its Units appear
 | A link chip shows no glyph | `data-link-icon` missing, or the `attr()` rule was scoped away | The glyph is CSS chrome (`interactive-document.css`) drawn from the attribute the renderer stamps; it is never part of the label |
 | An Einheit link 404s | Its Kurs or the Einheit itself is unpublished | `/einheiten/[unitId]` resolves through the DAL under the reader's RLS — no row, no redirect. Publish the Einheit, or accept the 404 as the archive rule working |
 | A link to a Sprungmarke opens the document at the top | The anchor id is not in that document's snapshot | The fragment is matched against `data-anchor-id` in the rendered DOM; a Sprungmarke deleted or re-stamped after the link was made no longer matches (that is #75's warning to add) |
+| A chip stays blue and clickable although its target is gone | The resolver was never answered — it **fails open** by design (#74) | Check `/api/link-target/[kind]/[id]` in the network tab: a non-OK status, a thrown fetch, or a body that is not a verdict (an unauthenticated request gets the proxy's HTML login redirect) all leave every chip untouched |
+| Every chip in a document degrades at once | Not a resolver verdict — the render failed | A verdict is per target; a document that lost all its links either fell back to the PNG or never rendered. Look for `Rendern fehlgeschlagen` in the console |
+| A locked chip navigates instead of opening the card | The element was mutated rather than replaced | The renderer's `followLink` listener has no handle to remove it with, so `applyLinkTargetDescriptor` replaces the anchor with a clone. Mutating it in place leaves that listener attached |
+| The unlock card offers an Einheit that cannot be bought | `archived` lost to `locked` in the decision | `describeLinkTarget` checks `kursPublished` **before** the entitlement, on purpose — the test „archived beats locked" pins it |
 
 ## File Reference Guide
 
@@ -569,6 +604,7 @@ Set `published = true/false` in the `kurse` table. The Kurs and its Units appear
 | Student document access + shared page-scale view | `src/lib/document-access.ts`, `src/lib/document-surface.ts`, `src/components/documents/DocumentArticle.tsx` |
 | Document overlay navigation | `src/app/@modal/*`, `src/components/documents/DocumentOverlay.tsx`, `src/components/documents/DocumentLink.tsx`, `src/app/layout.tsx` |
 | Where a link goes | `src/lib/link-navigation.ts`, `src/app/einheiten/[unitId]/page.tsx`, `makeLinksNavigable` in `src/lib/editor/document-render.ts` |
+| Whether a link still goes anywhere | `src/lib/link-target-state.ts`, `src/lib/unreachable-links.ts`, `src/app/api/link-target/[kind]/[id]/route.ts`, `getLinkTargetOwnership` in `src/lib/dal.ts`, `src/components/documents/LinkLockedCard.tsx` |
 | LaTeX editor core (controller + pure modules) | `src/lib/editor/*` |
 | LaTeX editor UI (page, shell, toolbar, export, drafts) | `src/app/admin/editor/*`, `src/components/admin/editor/*` |
 | Standalone reference editor (parity ground truth) | `latexEditor/*.html` |
@@ -576,4 +612,4 @@ Set `published = true/false` in the `kurse` table. The Kurs and its Units appear
 
 ---
 
-**Last Updated**: 2026-07-05 | **Version**: 4.3
+**Last Updated**: 2026-08-10 | **Version**: 4.4

--- a/src/app/api/link-target/[kind]/[id]/route.ts
+++ b/src/app/api/link-target/[kind]/[id]/route.ts
@@ -54,7 +54,19 @@ export async function GET(
   }
 
   const role = user.app_metadata?.['role'] as string | undefined
-  const target = await getLinkTargetOwnership(kind, id)
+
+  let target
+  try {
+    target = await getLinkTargetOwnership(kind, id)
+  } catch (err) {
+    // A read that FAILED is not a target that is GONE. Answering `missing`
+    // here would degrade a perfectly live link to plain text over a transient
+    // database error; a non-OK status is what the browser half reads as „no
+    // verdict", leaving every chip exactly as it was.
+    console.error('[link-target] Auflösung fehlgeschlagen:', err)
+    return NextResponse.json({ error: 'Link-Ziel konnte nicht aufgelöst werden.' }, { status: 503 })
+  }
+
   // Skipped where nothing is gated — a Kurs and an Einheit cost no purchase to
   // reach, so the query would be asked and thrown away.
   const entitled = target?.gatedBy

--- a/src/app/api/link-target/[kind]/[id]/route.ts
+++ b/src/app/api/link-target/[kind]/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getLinkTargetOwnership, userHasUnitAccess } from '@/lib/dal'
+import { describeLinkTarget } from '@/lib/link-target-state'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * The link resolver (#74) — „is this link's target still reachable, and if not,
+ * why", answered as a minimal descriptor and nothing more.
+ *
+ * A THIN SHELL, deliberately: auth, then one identity-free privileged read
+ * (`getLinkTargetOwnership`), then one entitlement read under the reader's own
+ * RLS, then the pure decision. Everything about who may be told what lives in
+ * `describeLinkTarget`, which is where it can be unit-tested as the paywall
+ * rule it is.
+ *
+ * It mirrors the file proxies rather than inventing an access shape: same
+ * authentication requirement, same `app_metadata.role` admin bypass, and the
+ * same rule that the answer is the least the caller needs. What it never
+ * returns is document content, a storage path, or anything at all about a
+ * target the reader may not reach.
+ *
+ * The entitlement is read through the DAL with the READER'S OWN client, not the
+ * privileged one: RLS on `entitlements` already restricts it to their own rows,
+ * so no plumbing mistake here can hand someone another student's access.
+ */
+
+const ParamsSchema = z.strictObject({
+  kind: z.enum(['kurs', 'unit', 'document']),
+  id: z.string().uuid(),
+})
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ kind: string; id: string }> }
+) {
+  const parsed = ParamsSchema.safeParse(await params)
+  // A malformed target is a bug in the caller, not a state a student can be
+  // in: every chip is built from a validated link node. Answering 400 rather
+  // than „missing" keeps that distinction visible instead of dressing it up as
+  // a deleted document.
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Ungültige Link-Referenz.' }, { status: 400 })
+  }
+  const { kind, id } = parsed.data
+
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  // The proxy already redirects unauthenticated visitors; guard defensively in
+  // case its matcher is ever loosened. JSON rather than a redirect — this is
+  // only ever fetched, never navigated to.
+  if (!user) {
+    return NextResponse.json({ error: 'Nicht angemeldet.' }, { status: 401 })
+  }
+
+  const role = user.app_metadata?.['role'] as string | undefined
+  const target = await getLinkTargetOwnership(kind, id)
+  // Skipped where nothing is gated — a Kurs and an Einheit cost no purchase to
+  // reach, so the query would be asked and thrown away.
+  const entitled = target?.gatedBy
+    ? await userHasUnitAccess(user.id, target.gatedBy.id, role)
+    : false
+
+  const descriptor = describeLinkTarget(target, { isAdmin: role === 'admin', entitled })
+
+  return NextResponse.json(descriptor, {
+    // Per-reader by definition — one student's „locked" is another's „ok", and
+    // a purchase changes the answer mid-session. Nothing may hold it but the
+    // page that asked.
+    headers: { 'Cache-Control': 'private, no-store' },
+  })
+}

--- a/src/components/documents/DocumentOverlay.tsx
+++ b/src/components/documents/DocumentOverlay.tsx
@@ -74,7 +74,15 @@ export function DocumentOverlay({
       // a vaguely-named dialog instead of an unnamed one.
       aria-label="Dokument"
       aria-labelledby={titleId}
+      // ONLY THIS DIALOG'S OWN CANCEL COUNTS (#103). `cancel` does not bubble in
+      // the DOM, but React replays it along the COMPONENT tree, so Escape over a
+      // dialog rendered inside the document — the locked-link card — arrives
+      // here too and used to take the whole overlay down with it, discarding
+      // everything the student had typed. The identity check is the same one
+      // `onMouseDown` makes for the backdrop, and it holds for any dialog
+      // embedded below, not just that one.
       onCancel={(event) => {
+        if (event.target !== dialogRef.current) return
         event.preventDefault()
         dismiss()
       }}

--- a/src/components/documents/InteractiveDocument.tsx
+++ b/src/components/documents/InteractiveDocument.tsx
@@ -7,7 +7,10 @@ import { renderDocumentJson } from '@/lib/editor/document-render'
 import { readDocumentJson } from '@/lib/editor/document-version'
 import { loadMathJax } from '@/lib/editor/mathjax-loader'
 import { documentIdInPath, linkHref, linkOpensOverlay } from '@/lib/link-navigation'
+import type { LockedLinkTarget } from '@/lib/link-target-state'
+import { resolveRenderedLinks } from '@/lib/unreachable-links'
 import { DocumentPng } from './DocumentPng'
+import { LinkLockedCard } from './LinkLockedCard'
 import { Watermark } from './Watermark'
 import './interactive-document.css'
 
@@ -75,6 +78,12 @@ function LiveDocument({
   const snapshot = useMemo(() => readDocumentJson(content), [content])
   const hostRef = useRef<HTMLDivElement | null>(null)
   const [renderFailed, setRenderFailed] = useState(false)
+  // The one thing the DOM below the host hands back to React (#74): a link into
+  // material this student has not bought opens the unlock card rather than
+  // travelling to the refusal it would otherwise land on. `useState`'s setter is
+  // stable, so passing it into the effect does not make the effect re-run — and
+  // re-running it would rebuild the document and lose everything typed into it.
+  const [lockedTarget, setLockedTarget] = useState<LockedLinkTarget | null>(null)
 
   // The router is reached through a ref rather than through the effect's
   // dependencies, and that is not a style choice: re-running the effect calls
@@ -144,8 +153,12 @@ function LiveDocument({
       host.closest('dialog') === window.document.querySelector('dialog[open]') &&
       documentIdInPath(window.location.pathname) === docId
 
+    // Cancels the link resolver's DOM writes when this document goes away —
+    // the requests themselves are left to finish and their answers discarded.
+    const linkResolution = new AbortController()
+
     try {
-      const { renderTargets } = renderDocumentJson(snapshot.doc, host, {
+      const { renderTargets, links: renderedLinks } = renderDocumentJson(snapshot.doc, host, {
         imageUrl: (imageId) => `/api/image/${imageId}`,
         linkHref,
         // Client-side, so the page underneath is never unmounted and the
@@ -181,6 +194,18 @@ function LiveDocument({
         onRecompute: typeset,
       })
       typeset(renderTargets)
+      // Which of those chips actually goes anywhere (#74). Asynchronous and
+      // deliberately not awaited: the document is already on screen and
+      // readable, and a link that turns out to be locked or gone is rewritten
+      // in place a moment later. Failures inside are already swallowed one
+      // request at a time — every chip is simply left alone — so this catch is
+      // for the DOM writes.
+      void resolveRenderedLinks(renderedLinks, {
+        onLocked: setLockedTarget,
+        signal: linkResolution.signal,
+      }).catch((err) => {
+        console.error(`[InteractiveDocument ${docId}] Link-Auflösung fehlgeschlagen:`, err)
+      })
       // Deliberately UNGUARDED, unlike the two paths above: this runs once per
       // mount, so only the copy that was just created by the navigation can
       // reach it. Asking `addressesThisDocument()` here would instead make the
@@ -212,6 +237,7 @@ function LiveDocument({
 
     return () => {
       cancelled = true
+      linkResolution.abort()
       window.removeEventListener('hashchange', onHashChange)
     }
   }, [snapshot, docId])
@@ -222,6 +248,12 @@ function LiveDocument({
     <div className="relative mt-2">
       <div ref={hostRef} className="dokum-document" />
       <Watermark id={watermarkId} />
+      {/* Outside the host, which the renderer owns — React may only reconcile
+          out here. A modal `<dialog>` lands in the top layer regardless, so
+          sitting inside a `relative` box costs it no stacking. */}
+      {lockedTarget && (
+        <LinkLockedCard target={lockedTarget} onDismiss={() => setLockedTarget(null)} />
+      )}
     </div>
   )
 }

--- a/src/components/documents/LinkLockedCard.tsx
+++ b/src/components/documents/LinkLockedCard.tsx
@@ -67,6 +67,10 @@ export function LinkLockedCard({
   return (
     <dialog
       ref={dialogRef}
+      // `aria-labelledby` wins whenever it resolves; the static label is the
+      // net under it, so a state that failed to render the line below degrades
+      // to a vaguely-named dialog rather than an unnamed one (DocumentOverlay
+      // carries the same pair for the same reason).
       aria-label="Einheit gesperrt"
       aria-labelledby={titleId}
       onClose={onDismiss}

--- a/src/components/documents/LinkLockedCard.tsx
+++ b/src/components/documents/LinkLockedCard.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import UnitPaywall from '@/components/kurse/UnitPaywall'
+import type { LockedLinkTarget } from '@/lib/link-target-state'
+
+/**
+ * What a link into material the student has not bought opens (#74, spec #63
+ * user story 21): the Einheit it lives in, the teaser that describes it, and
+ * the button that unlocks it.
+ *
+ * ⚠ THE POINT IS THAT IT OPENS IN PLACE. Following the link would land on the
+ * same refusal any unentitled read gets, and — worse for a document full of
+ * live inputs — unmount everything the student has typed on the way. So the
+ * chip does not navigate: it hands the descriptor the resolver returned to
+ * React, and React puts this on top. Nothing is fetched here; the card renders
+ * from what the resolver already said.
+ *
+ * The offer itself is {@link UnitPaywall}, the SAME component the locked
+ * Einheit page shows, rather than a second copy of the unlock UI. A student who
+ * meets the paywall through a link and one who meets it by opening the Einheit
+ * see the same words and the same price, and the Einheit's teaser reaches both
+ * surfaces by construction instead of by two people remembering to update it.
+ *
+ * A native `<dialog>` for the same reasons as the document overlay: a real
+ * focus trap, Escape, and an inert background from the platform. Unlike that
+ * overlay this pushes NO history entry — nothing about the URL changes when a
+ * card opens — so closing it is ordinary `close()` and browser Back still means
+ * „leave the document", which is what a student who never opened a card
+ * expects too.
+ */
+export function LinkLockedCard({
+  target,
+  onDismiss,
+}: {
+  target: LockedLinkTarget
+  onDismiss: () => void
+}) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null)
+  const pressedBackdrop = useRef(false)
+  const titleId = `link-locked-${target.unit.id}`
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    // Remembered before `showModal()` moves focus off it: the chip that opened
+    // the card is still in the document underneath, and a keyboard user has to
+    // come back to their place in the sentence rather than to `<body>`.
+    const opener = document.activeElement
+    if (!dialog.open) dialog.showModal()
+
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+      if (dialog.open) dialog.close()
+      if (opener instanceof HTMLElement && opener.isConnected) opener.focus()
+    }
+  }, [])
+
+  // EVERY dismissal goes through the element's own `close()`, so Escape (which
+  // closes natively) and the two buttons cannot end up in different states —
+  // React unmounts the card from the one `onClose` all of them produce.
+  const dismiss = () => dialogRef.current?.close()
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-label="Einheit gesperrt"
+      aria-labelledby={titleId}
+      onClose={onDismiss}
+      // The press decides, not the click: a click's target is the common
+      // ancestor of press and release, so releasing past the panel edge after
+      // selecting text inside it would otherwise dismiss the card.
+      onMouseDown={(event) => {
+        pressedBackdrop.current = event.target === dialogRef.current
+      }}
+      onClick={(event) => {
+        if (pressedBackdrop.current && event.target === dialogRef.current) dismiss()
+      }}
+      className="m-auto w-[92vw] max-w-lg rounded-xl border-0 bg-transparent p-0 backdrop:bg-black/40"
+    >
+      <div className="rounded-xl bg-[#fffdf8] p-1 shadow-2xl">
+        <div className="flex justify-end px-3 pt-2">
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label="Hinweis schließen"
+            className="rounded-md px-2 py-1 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+          >
+            Schließen ✕
+          </button>
+        </div>
+        <p id={titleId} className="px-6 text-sm text-gray-600">
+          Das verlinkte Dokument{' '}
+          <span className="font-medium text-gray-900">{target.title}</span> gehört zu einer Einheit,
+          die du noch nicht freigeschaltet hast.
+        </p>
+        {/* `mt-8` on the paywall's own box is the spacing below this line. */}
+        <UnitPaywall
+          unitId={target.unit.id}
+          title={target.unit.title}
+          description={target.unit.description}
+        />
+        <div className="h-4" />
+      </div>
+    </dialog>
+  )
+}

--- a/src/components/documents/interactive-document.css
+++ b/src/components/documents/interactive-document.css
@@ -284,6 +284,40 @@
   content: attr(data-link-icon) '\00a0';
 }
 
+/* A link into an Einheit the student has not bought (#74). Still a chip and
+   still clickable — it opens the unlock card — but it wears the amber of the
+   paywall rather than the blue of a link that goes somewhere now, so „I can
+   read this" and „I can buy this" are not the same colour. The lock glyph comes
+   through the same `data-link-icon` attribute the kind glyphs do. */
+.dokum-document .doc-link[data-link-state='locked'] {
+  background: #fffbeb;
+  color: #92400e;
+  border-color: #fcd34d;
+}
+
+.dokum-document .doc-link[data-link-state='locked']:hover {
+  background: #fef3c7;
+}
+
+.dokum-document .doc-link[data-link-state='locked']:focus-visible {
+  outline-color: #b45309;
+}
+
+/* A link whose target is archived or deleted (#74). NOT a chip: it is plain
+   text now, because the one thing it must not do is look like something worth
+   clicking. The author's words stay exactly as they were written so the
+   sentence still reads, and the note beside them is real text — quiet, but read
+   aloud like everything else. */
+.dokum-document .doc-link-gone {
+  color: inherit;
+}
+
+.dokum-document .doc-link-gone-note {
+  color: #6b7280;
+  font-size: 0.85em;
+  white-space: nowrap;
+}
+
 /* A Sprungmarke is where a link LANDS — the spot is scrolled to, so it must
    not end up flush against the top edge, under the sticky header of either
    surface that shows a document. */

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import type { LinkTargetKind } from '@/lib/editor/links'
+
 export const STORAGE_BUCKET = 'pdfs'
 
 export const MAX_FILE_SIZE_BYTES = 4 * 1024 * 1024 // 4 MB
@@ -57,4 +59,20 @@ export function kursUrl(kursId: string): string {
 // following an Einheit link needs no client-side lookup of its Kurs.
 export function unitUrl(unitId: string): string {
   return `/einheiten/${unitId}`
+}
+
+// The resolver a rendered link chip asks whether its target is still reachable
+// (#74). Kind and id both ride in the path, mirroring the file proxies: this is
+// a read of one named thing, not a query.
+//
+// It answers with a verdict and, for a locked target, the Einheit that unlocks
+// it — never content. The route is the only caller of the DAL's one
+// RLS-bypassing read, and `describeLinkTarget` is what decides how much of it
+// may cross.
+// The id is percent-encoded even though the route rejects anything that is not
+// a uuid: it is read off a chip's dataset in the browser, and a value that
+// could climb out of its path segment must not be able to address a different
+// route on the way to being refused.
+export function linkTargetUrl(kind: LinkTargetKind, id: string): string {
+  return `/api/link-target/${kind}/${encodeURIComponent(id)}`
 }

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -1,5 +1,8 @@
 import 'server-only'
 import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import type { LinkTargetKind } from '@/lib/editor/links'
+import type { LinkTargetOwnership } from '@/lib/link-target-state'
 import type {
   Document,
   DocumentImage,
@@ -433,6 +436,94 @@ export async function getEditorImageFilePath(
     .eq('id', imageId)
     .single()
   return data ?? null
+}
+
+// ── Link target resolution (#74) ────────────────────────────────────────────
+
+/**
+ * What a link's target IS — title, whether its Kurs is still published, and
+ * the Einheit whose entitlement gates it. `null` when there is no such row.
+ *
+ * ⚠ THE ONE READ IN THIS FILE THAT BYPASSES RLS, and it does so for a reason
+ * the policies cannot serve: `documents` SELECT requires an entitlement, so the
+ * student we want to SELL to gets no row and cannot be told which Einheit to
+ * buy — locked and deleted look identical from the browser (#74).
+ *
+ * Three rules keep that bypass safe, and all three are in this function:
+ *
+ * 1. **It selects only what a refusal may name.** No `content`, no
+ *    `file_path`, no `description` of the target itself — the columns are
+ *    listed one by one and the list is the audit.
+ * 2. **It never learns who is asking.** No user id, no role, no entitlement
+ *    read: it answers „what is this" and nothing about „may you have it".
+ *    Being identity-free is what makes it unable to leak per-reader data.
+ * 3. **Its result must go through `describeLinkTarget` before crossing to the
+ *    browser** — that is where the reader's admin flag and entitlement decide
+ *    which of these fields the answer is allowed to carry, and every field
+ *    below is withheld from every verdict except `locked`.
+ *
+ * Consequently there is exactly one caller, `/api/link-target/[kind]/[id]`. A
+ * page rendering this straight into HTML would be a new way to read the
+ * catalogue.
+ */
+export async function getLinkTargetOwnership(
+  kind: LinkTargetKind,
+  id: string
+): Promise<LinkTargetOwnership | null> {
+  const supabase = createServiceClient()
+
+  if (kind === 'kurs') {
+    const { data } = await supabase.from('kurse').select('title, published').eq('id', id).maybeSingle()
+    if (!data) return null
+    // A Kurs page costs nothing to open — nothing gates it but its own
+    // `published` flag, which is the archive.
+    return { title: data.title as string, kursPublished: data.published as boolean, gatedBy: null }
+  }
+
+  if (kind === 'unit') {
+    const { data } = await supabase
+      .from('units')
+      .select('title, kurse!inner(published)')
+      .eq('id', id)
+      .maybeSingle()
+    if (!data) return null
+    const row = data as unknown as { title: string; kurse: { published: boolean } }
+    // Deliberately NOT gated, even though buying an Einheit is the whole
+    // paywall: the Einheit page is readable without the purchase and IS the
+    // unlock surface (paywall + teaser + „Freischalten"). Interposing a card
+    // in front of a link to it would sell the student a worse copy of the page
+    // they are one click from.
+    return { title: row.title, kursPublished: row.kurse.published, gatedBy: null }
+  }
+
+  const { data } = await supabase
+    .from('documents')
+    .select('title, tasks!inner(units!inner(id, title, description, kurse!inner(published)))')
+    .eq('id', id)
+    .maybeSingle()
+  if (!data) return null
+  const row = data as unknown as LinkTargetDocumentOwnershipRow
+  const unit = row.tasks.units
+  return {
+    title: row.title,
+    kursPublished: unit.kurse.published,
+    gatedBy: { id: unit.id, title: unit.title, description: unit.description },
+  }
+}
+
+// The raw PostgREST shape of the document query above — nested embeds are not
+// inferred without generated types, and the `!inner` joins guarantee the
+// ancestry exists (getDocumentWithAncestry precedent).
+type LinkTargetDocumentOwnershipRow = {
+  title: string
+  tasks: {
+    units: {
+      id: string
+      title: string
+      description: string | null
+      kurse: { published: boolean }
+    }
+  }
 }
 
 // ── Entitlement queries ─────────────────────────────────────────────────────

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -473,7 +473,8 @@ export async function getLinkTargetOwnership(
   const supabase = createServiceClient()
 
   if (kind === 'kurs') {
-    const { data } = await supabase.from('kurse').select('title, published').eq('id', id).maybeSingle()
+    const { data, error } = await supabase.from('kurse').select('title, published').eq('id', id).maybeSingle()
+    if (error) throw linkTargetReadFailed(kind, error)
     if (!data) return null
     // A Kurs page costs nothing to open — nothing gates it but its own
     // `published` flag, which is the archive.
@@ -481,11 +482,12 @@ export async function getLinkTargetOwnership(
   }
 
   if (kind === 'unit') {
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from('units')
       .select('title, kurse!inner(published)')
       .eq('id', id)
       .maybeSingle()
+    if (error) throw linkTargetReadFailed(kind, error)
     if (!data) return null
     const row = data as unknown as { title: string; kurse: { published: boolean } }
     // Deliberately NOT gated, even though buying an Einheit is the whole
@@ -496,11 +498,12 @@ export async function getLinkTargetOwnership(
     return { title: row.title, kursPublished: row.kurse.published, gatedBy: null }
   }
 
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from('documents')
     .select('title, tasks!inner(units!inner(id, title, description, kurse!inner(published)))')
     .eq('id', id)
     .maybeSingle()
+  if (error) throw linkTargetReadFailed(kind, error)
   if (!data) return null
   const row = data as unknown as LinkTargetDocumentOwnershipRow
   const unit = row.tasks.units
@@ -509,6 +512,24 @@ export async function getLinkTargetOwnership(
     kursPublished: unit.kurse.published,
     gatedBy: { id: unit.id, title: unit.title, description: unit.description },
   }
+}
+
+/**
+ * ⚠ A FAILED READ IS THROWN, NEVER COLLAPSED INTO `null`.
+ *
+ * `null` here means „no such row", which becomes the verdict `missing` and
+ * degrades a live link to plain text in the middle of a sentence. A transient
+ * database failure returning `null` would therefore silently unlink a document
+ * that is perfectly fine — the exact opposite of the fail-open rule the rest of
+ * this path is built on, and invisible, because it arrives as a confident 200.
+ *
+ * The route turns this into a non-OK status, which the browser half reads as
+ * „no verdict" and leaves every chip exactly as the renderer built it. This is
+ * the one DAL function that distinguishes the two, because it is the one whose
+ * empty result is a user-visible statement rather than a 404.
+ */
+function linkTargetReadFailed(kind: LinkTargetKind, error: { message: string }): Error {
+  return new Error(`Link-Ziel (${kind}) konnte nicht gelesen werden: ${error.message}`)
 }
 
 // The raw PostgREST shape of the document query above — nested embeds are not

--- a/src/lib/editor/document-render.test.ts
+++ b/src/lib/editor/document-render.test.ts
@@ -724,8 +724,19 @@ describe('renderDocumentJson — link chips', () => {
   })
 
   it('leaves a document without links exactly as it was', () => {
-    const { host } = render(DOC)
+    const { host, result } = render(DOC)
     expect(host.querySelector('.doc-link')).toBeNull()
     expect(host.querySelector('a')).toBeNull()
+    expect(result.links).toEqual([])
+  })
+
+  it('reports every chip it built, with the link it carries (#74)', () => {
+    // The same contract `renderTargets` has: whether a target is still
+    // REACHABLE is a server question this module refuses to ask, exactly as it
+    // refuses to typeset — so it hands the elements back and the caller
+    // resolves them.
+    const target = { docId: DOC_ID, anchorId: 'anc_1' }
+    const { host, result } = render(withLink(target))
+    expect(result.links).toEqual([{ target, label: 'Kapitel 3', anchor: chipIn(host) }])
   })
 })

--- a/src/lib/editor/document-render.ts
+++ b/src/lib/editor/document-render.ts
@@ -74,6 +74,7 @@ import {
 } from './field-resolver'
 import {
   LINK_CHIP_SELECTOR,
+  isPlainLeftClick,
   linkTargetIcon,
   linkTargetKindLabel,
   readLinkChip,
@@ -132,7 +133,20 @@ export interface DocumentRenderResult {
    * `data-raw-latex`. The caller MathJax-renders them.
    */
   renderTargets: HTMLElement[]
+  /**
+   * Every link chip that became a navigable anchor, in document order, with
+   * the link it carries (#74).
+   *
+   * Reported for the same reason `renderTargets` is: whether a target is still
+   * REACHABLE — bought, archived, deleted — is a server question this module
+   * refuses to ask, exactly as it refuses to typeset. The caller resolves them
+   * and rewrites the ones that turn out to be unreachable.
+   */
+  links: RenderedDocumentLink[]
 }
+
+/** A link as it ended up in the rendered document: its data and its element. */
+export type RenderedDocumentLink = DocumentLink & { anchor: HTMLAnchorElement }
 
 const FIELD_SELECTOR = '.input-field, .output-field'
 
@@ -164,13 +178,13 @@ export function renderDocumentJson(
   // it by class and never descends into it, and the graph reads only its
   // dataset — so span or input makes no difference to any resolved value.
   makeInputsEditable(container, graph, renderTargets, adapters)
-  makeLinksNavigable(container, adapters)
+  const links = makeLinksNavigable(container, adapters)
 
   resolveDocument(container, graph, renderTargets, { writeFormulaText: true })
 
   stripEditorChrome(container)
 
-  return { renderTargets }
+  return { renderTargets, links }
 }
 
 /**
@@ -440,7 +454,11 @@ function isStudentControl(el: HTMLElement): el is HTMLInputElement {
  * quietly different on a touch screen. The label plus the kind glyph is the
  * whole of "say where you go before I click".
  */
-function makeLinksNavigable(container: HTMLElement, adapters: DocumentRenderAdapters): void {
+function makeLinksNavigable(
+  container: HTMLElement,
+  adapters: DocumentRenderAdapters
+): RenderedDocumentLink[] {
+  const rendered: RenderedDocumentLink[] = []
   for (const chip of Array.from(container.querySelectorAll<HTMLElement>(LINK_CHIP_SELECTOR))) {
     const link = readLinkChip(chip)
     // Not reachable through the importer, which only builds a chip from a
@@ -460,7 +478,9 @@ function makeLinksNavigable(container: HTMLElement, adapters: DocumentRenderAdap
       event.preventDefault()
       follow(link.target, href)
     })
+    rendered.push({ ...link, anchor })
   }
+  return rendered
 }
 
 /** Swaps an authoring chip for the student's navigable one. */
@@ -488,17 +508,6 @@ function replaceWithLinkAnchor(
   anchor.textContent = link.label
   chip.replaceWith(anchor)
   return anchor
-}
-
-/**
- * A click the app should handle itself. Everything else — a modifier held, the
- * middle button — is the student asking the BROWSER for something (a new tab, a
- * new window), and intercepting it would take that away.
- */
-function isPlainLeftClick(event: MouseEvent): boolean {
-  return (
-    event.button === 0 && !event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey
-  )
 }
 
 // ── Field graph over the rendered DOM ───────────────────────────────────────

--- a/src/lib/editor/links.ts
+++ b/src/lib/editor/links.ts
@@ -134,7 +134,16 @@ export const LINK_KIND_ICON: Record<LinkTargetKind, string> = {
   document: '📄',
 }
 
-/** A Sprungmarke is not a kind of its own, but it does get its own glyph. */
+/**
+ * A Sprungmarke is not a kind of its own, but it does get its own glyph.
+ *
+ * ⚠ It is not the only one either: a chip whose target the student has not
+ * bought wears a lock instead (`lib/unreachable-links.ts`, #74). That one is
+ * deliberately NOT here — it says something about the READER rather than about
+ * the target, and entitlements are app knowledge this module stays free of. If
+ * you are chasing „where does a chip's glyph come from", it is these two plus
+ * {@link LINK_KIND_ICON}, all through `data-link-icon`.
+ */
 export const LINK_ANCHOR_ICON = '⚓'
 
 /** …and its own name, for the same reason (#73). */

--- a/src/lib/editor/links.ts
+++ b/src/lib/editor/links.ts
@@ -220,6 +220,24 @@ export function createLinkChip(docEl: Document, link: DocumentLink): HTMLElement
   return el
 }
 
+/**
+ * A click on a chip that the APP should handle itself. Everything else — a
+ * modifier held, the middle button — is the student asking the BROWSER for
+ * something (a new tab, a new window), and intercepting it would take that
+ * away.
+ *
+ * Lives here rather than beside either of its callers because both the live
+ * chip (document-render.ts) and the locked one (lib/unreachable-links.ts)
+ * intercept clicks, and a chip that answered a Ctrl-click differently
+ * depending on whether its target was bought would be the strangest possible
+ * inconsistency.
+ */
+export function isPlainLeftClick(event: MouseEvent): boolean {
+  return (
+    event.button === 0 && !event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey
+  )
+}
+
 // ── The picker seam ─────────────────────────────────────────────────────────
 //
 // The target tree is server data, so the picker itself is a React component —

--- a/src/lib/link-target-state.test.ts
+++ b/src/lib/link-target-state.test.ts
@@ -1,0 +1,167 @@
+/**
+ * link-target-state tests (#74).
+ *
+ * This is the paywall decision for links, so the suite is written as the
+ * questions a reviewer would ask about a paywall rather than as coverage of
+ * branches: who may see what, what may cross to the browser, and which rule
+ * wins when two of them apply at once.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  LinkTargetDescriptorSchema,
+  describeLinkTarget,
+  type LinkTargetOwnership,
+} from './link-target-state'
+
+const EINHEIT = {
+  id: '22222222-2222-4222-8222-222222222222',
+  title: 'Einheit 3 — Bewertung',
+  description: 'DCF, Multiples und die Fallstricke dazwischen.',
+}
+
+/** A Dokument: owned by an Einheit, so an entitlement gates it. */
+const DOKUMENT: LinkTargetOwnership = {
+  title: 'Aufgabe 2 — Herleitung',
+  kursPublished: true,
+  gatedBy: EINHEIT,
+}
+
+/** A Kurs or an Einheit: reachable without buying anything. */
+const OPEN: LinkTargetOwnership = {
+  title: 'Unternehmensbewertung',
+  kursPublished: true,
+  gatedBy: null,
+}
+
+const STUDENT = { isAdmin: false, entitled: false }
+const BUYER = { isAdmin: false, entitled: true }
+const ADMIN = { isAdmin: true, entitled: false }
+
+describe('describeLinkTarget — what the student is told', () => {
+  it('lets an entitled reader through', () => {
+    expect(describeLinkTarget(DOKUMENT, BUYER)).toEqual({ state: 'ok' })
+  })
+
+  it('lets anyone through to something nothing has to be bought for', () => {
+    // A Kurs page and an Einheit page are readable without a purchase — the
+    // Einheit page IS the unlock surface, so sending the student there beats
+    // any card this could put in the way.
+    expect(describeLinkTarget(OPEN, STUDENT)).toEqual({ state: 'ok' })
+  })
+
+  it('offers the unlock for material the reader has not bought', () => {
+    expect(describeLinkTarget(DOKUMENT, STUDENT)).toEqual({
+      state: 'locked',
+      title: DOKUMENT.title,
+      unit: EINHEIT,
+    })
+  })
+
+  it('reports a target that does not exist as gone', () => {
+    expect(describeLinkTarget(null, STUDENT)).toEqual({ state: 'missing' })
+  })
+
+  it('reports a target behind an archived Kurs as gone', () => {
+    expect(describeLinkTarget({ ...DOKUMENT, kursPublished: false }, BUYER)).toEqual({
+      state: 'archived',
+    })
+  })
+})
+
+describe('describeLinkTarget — the rules that decide between themselves', () => {
+  it('archived beats locked: retired material is never offered for sale', () => {
+    // The one ordering that matters. An unentitled reader looking at a link
+    // into an archived Kurs must NOT be shown a €3 unlock button for content
+    // the operator has taken down — they would pay for a dark Einheit.
+    expect(describeLinkTarget({ ...DOKUMENT, kursPublished: false }, STUDENT)).toEqual({
+      state: 'archived',
+    })
+  })
+
+  it('missing beats everything: nothing is described about a row that is not there', () => {
+    expect(describeLinkTarget(null, ADMIN)).toEqual({ state: 'missing' })
+    expect(describeLinkTarget(null, BUYER)).toEqual({ state: 'missing' })
+  })
+
+  it('an admin reaches archived material, exactly as every other reader does', () => {
+    // The archive is retained and admins keep opening it (spec #63) — the same
+    // bypass /api/file and isDocumentReadable already carry.
+    expect(describeLinkTarget({ ...DOKUMENT, kursPublished: false }, ADMIN)).toEqual({ state: 'ok' })
+    expect(describeLinkTarget(DOKUMENT, ADMIN)).toEqual({ state: 'ok' })
+  })
+
+  it('ignores the entitlement flag where nothing is gated by one', () => {
+    expect(describeLinkTarget(OPEN, BUYER)).toEqual(describeLinkTarget(OPEN, STUDENT))
+  })
+})
+
+describe('describeLinkTarget — what may cross to the browser', () => {
+  it('says nothing but the verdict for anything the reader may not have', () => {
+    // A student who cannot reach the target learns THAT and nothing else. The
+    // title of retired material, and whether a missing id was ever a document,
+    // both stay server-side.
+    for (const descriptor of [
+      describeLinkTarget({ ...DOKUMENT, kursPublished: false }, STUDENT),
+      describeLinkTarget(null, STUDENT),
+      describeLinkTarget(DOKUMENT, BUYER),
+    ]) {
+      expect(Object.keys(descriptor)).toEqual(['state'])
+    }
+  })
+
+  it('carries the Einheit and its teaser only where they are the offer', () => {
+    // The locked card has to name what the student would be buying, and the
+    // teaser is what sells it (spec #63 user story 52).
+    const descriptor = describeLinkTarget(DOKUMENT, STUDENT)
+    expect(descriptor).toMatchObject({ unit: { title: EINHEIT.title, description: EINHEIT.description } })
+  })
+
+  it('never carries document content, however the reader is placed', () => {
+    // The descriptor's shape is the guarantee: there is no field for it, and
+    // the schema below is strict, so a future field cannot arrive unnoticed.
+    for (const reader of [STUDENT, BUYER, ADMIN]) {
+      const json = JSON.stringify(describeLinkTarget(DOKUMENT, reader))
+      expect(json).not.toContain('content')
+      expect(json).not.toContain('file_path')
+    }
+  })
+})
+
+describe('LinkTargetDescriptorSchema — the wire contract', () => {
+  it('accepts every descriptor the decision can produce', () => {
+    for (const descriptor of [
+      describeLinkTarget(DOKUMENT, STUDENT),
+      describeLinkTarget(DOKUMENT, BUYER),
+      describeLinkTarget({ ...DOKUMENT, kursPublished: false }, STUDENT),
+      describeLinkTarget(null, STUDENT),
+    ]) {
+      expect(LinkTargetDescriptorSchema.parse(descriptor)).toEqual(descriptor)
+    }
+  })
+
+  it('refuses a locked verdict with no Einheit to unlock', () => {
+    // A locked card that cannot name the Einheit has no offer to make, so the
+    // client must not be handed one.
+    expect(LinkTargetDescriptorSchema.safeParse({ state: 'locked' }).success).toBe(false)
+    expect(
+      LinkTargetDescriptorSchema.safeParse({ state: 'locked', title: 'X', unit: null }).success
+    ).toBe(false)
+  })
+
+  it('refuses a verdict it does not know, rather than passing it through', () => {
+    expect(LinkTargetDescriptorSchema.safeParse({ state: 'kaputt' }).success).toBe(false)
+    // Strict: a field nobody declared is a field nobody vetted.
+    expect(
+      LinkTargetDescriptorSchema.safeParse({ state: 'archived', title: 'geheim' }).success
+    ).toBe(false)
+  })
+
+  it('refuses the login page an unauthenticated fetch would land on', () => {
+    // The proxy answers an unauthenticated /api request with a redirect to the
+    // login page, so the client's parse is what stops HTML being read as a
+    // verdict — and the chip is left alone instead.
+    expect(LinkTargetDescriptorSchema.safeParse('<!DOCTYPE html>').success).toBe(false)
+    expect(LinkTargetDescriptorSchema.safeParse(null).success).toBe(false)
+  })
+})

--- a/src/lib/link-target-state.ts
+++ b/src/lib/link-target-state.ts
@@ -1,0 +1,123 @@
+/**
+ * link-target-state — is a link's target reachable, and if not, why (#74,
+ * spec #63 §6, user stories 21–23).
+ *
+ * ⚠ THIS EXISTS BECAUSE RLS HIDES THE DIFFERENCE. A link resolves by reading
+ * the target's row, and that read is entitlement-gated — so an unentitled
+ * student's lookup returns **no row at all**, and locked is indistinguishable
+ * from deleted in the browser. Telling the student „das liegt in Einheit 3,
+ * schalte sie frei" requires knowing the target exists and which Einheit owns
+ * it, which is exactly what the policy withholds from the reader we want to
+ * sell to. So a server-side resolver reads it with a privileged client and
+ * answers with a **minimal descriptor** — never the content.
+ *
+ * This module is the decision that route makes, split out from the reading so
+ * it can be tested as what it is: a paywall rule. Pure, and free of
+ * `server-only` on purpose — the browser half needs the same shapes to read
+ * the answer, and one declaration is what stops the two ends drifting apart.
+ *
+ * FOUR VERDICTS, AND THE ORDER BETWEEN THEM IS LOAD-BEARING:
+ *
+ * - `missing`  — no such row. Nothing else is said about it.
+ * - `archived` — it exists, but its Kurs is unpublished. Beats `locked`: the
+ *                material is retired, and offering to sell it would take €3
+ *                for an Einheit that stays dark.
+ * - `locked`   — it exists and is live, the reader has simply not bought the
+ *                Einheit. The one verdict that carries anything with it.
+ * - `ok`       — reachable. Also what an admin gets for everything that
+ *                exists, the same bypass `isDocumentReadable` and /api/file
+ *                already carry, because the archive is retained for them.
+ */
+
+import { z } from 'zod'
+
+/**
+ * What a target IS, as a privileged read finds it — identity-free on purpose:
+ * this half never sees who is asking, so it cannot leak per-reader data.
+ */
+export interface LinkTargetOwnership {
+  /** The target's own title. Crosses to the browser only on `locked`. */
+  title: string
+  /** Whether the Kurs that owns it is published — what makes the archive dark. */
+  kursPublished: boolean
+  /**
+   * The Einheit whose entitlement gates the target, and the teaser that sells
+   * it. `null` where nothing has to be bought: a Kurs page and an Einheit page
+   * are readable without a purchase, and the Einheit page is itself the unlock
+   * surface — sending the student there beats any card we could interpose.
+   */
+  gatedBy: UnitTeaser | null
+}
+
+/** The Einheit a locked link offers to unlock, named the way it sells itself. */
+export interface UnitTeaser {
+  id: string
+  title: string
+  description: string | null
+}
+
+/** Who is asking. Both flags come from the request, never from stored content. */
+export interface LinkTargetReader {
+  /** `app_metadata.role === 'admin'` — reaches the retained archive. */
+  isAdmin: boolean
+  /** Holds an entitlement for `gatedBy`. Meaningless when nothing is gated. */
+  entitled: boolean
+}
+
+const UnitTeaserSchema = z.strictObject({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+})
+
+/**
+ * The wire shape of a verdict — schema first, type derived, so the client's
+ * parse and the server's return can only ever describe the same thing.
+ *
+ * `strictObject` throughout, matching the document JSON's contract: a field
+ * nobody declared is a field nobody vetted, and on a route whose whole job is
+ * withholding things, an unnoticed extra key is the failure mode.
+ */
+export const LinkTargetDescriptorSchema = z.discriminatedUnion('state', [
+  z.strictObject({ state: z.literal('ok') }),
+  z.strictObject({ state: z.literal('archived') }),
+  z.strictObject({ state: z.literal('missing') }),
+  z.strictObject({
+    state: z.literal('locked'),
+    /** The target's title — the student is told what they would be buying. */
+    title: z.string(),
+    /** Required: a locked card that cannot name the Einheit has no offer. */
+    unit: UnitTeaserSchema,
+  }),
+])
+
+export type LinkTargetDescriptor = z.infer<typeof LinkTargetDescriptorSchema>
+
+export type LinkTargetState = LinkTargetDescriptor['state']
+
+/** The one verdict that carries an offer with it — what the unlock card shows. */
+export type LockedLinkTarget = Extract<LinkTargetDescriptor, { state: 'locked' }>
+
+/**
+ * The whole decision, and the whole of what may cross to the browser with it.
+ *
+ * Deciding the verdict and choosing the payload are ONE function deliberately:
+ * every early return here is both „this is the verdict" and „and this is all
+ * you are told", so there is no second place where a field could be attached
+ * to a verdict that must not carry it.
+ *
+ * `target` is nullable because that is how a privileged read reports „no such
+ * row", and the caller must not have to invent a shape for nothing.
+ */
+export function describeLinkTarget(
+  target: LinkTargetOwnership | null,
+  reader: LinkTargetReader
+): LinkTargetDescriptor {
+  if (!target) return { state: 'missing' }
+  if (reader.isAdmin) return { state: 'ok' }
+  if (!target.kursPublished) return { state: 'archived' }
+  if (target.gatedBy && !reader.entitled) {
+    return { state: 'locked', title: target.title, unit: target.gatedBy }
+  }
+  return { state: 'ok' }
+}

--- a/src/lib/unreachable-links.test.ts
+++ b/src/lib/unreachable-links.test.ts
@@ -164,10 +164,11 @@ describe('applyLinkTargetDescriptor — a locked target', () => {
     expect(chip.getAttribute('aria-label')).toContain('gesperrt')
   })
 
-  it('reveals nothing about the target beyond the words already in the sentence', () => {
-    // The Einheit is the offer and may be named. The locked DOCUMENT's title is
-    // not the offer, and putting it in the page would tell an unentitled reader
-    // what is behind the paywall.
+  it('leaves the sentence itself carrying only the words the author wrote', () => {
+    // The descriptor knows the target's title and the card DOES show it — the
+    // student is told what they would be buying. What must not happen is the
+    // resolver rewriting the running text of a document around it: the chip
+    // stays the author's label, so a verdict can never edit the material.
     const { host, link } = renderOneLink()
     applyLinkTargetDescriptor(link, LOCKED, () => {})
     expect(host.textContent).not.toContain(LOCKED.title)

--- a/src/lib/unreachable-links.test.ts
+++ b/src/lib/unreachable-links.test.ts
@@ -1,0 +1,264 @@
+// @vitest-environment jsdom
+/**
+ * unreachable-links tests (#74).
+ *
+ * Behavioural, in the style of the document-render suite: given what the
+ * resolver says about a target, what does the STUDENT end up with in the
+ * sentence — is it still clickable, where does it go, and what does it say?
+ *
+ * The links under test are produced by the real renderer rather than by hand,
+ * because half of what this module has to get right is UNDOING what the
+ * renderer did: a locked chip must stop following its link through the router,
+ * and only replacing the element it bound its listener to achieves that.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { LatestEditorDocumentJson } from '@/lib/editor/document-json'
+import { renderDocumentJson } from '@/lib/editor/document-render'
+import { linkTargetId, type LinkTarget } from '@/lib/editor/links'
+import type { LinkTargetDescriptor } from '@/lib/link-target-state'
+import { applyLinkTargetDescriptor, resolveRenderedLinks } from './unreachable-links'
+
+const DOC_ID = '11111111-1111-4111-8111-111111111111'
+const KURS_ID = '33333333-3333-4333-8333-333333333333'
+const UNIT_ID = '22222222-2222-4222-8222-222222222222'
+
+const LOCKED: LinkTargetDescriptor = {
+  state: 'locked',
+  title: 'Aufgabe 2 — Herleitung',
+  unit: { id: UNIT_ID, title: 'Einheit 3', description: 'DCF und Multiples.' },
+}
+
+function withLink(target: LinkTarget, label = 'Kapitel 3'): LatestEditorDocumentJson {
+  return {
+    version: '1.1',
+    variables: [],
+    content: [
+      {
+        type: 'paragraph',
+        children: [{ text: 'Siehe ' }, { type: 'link', target, label }, { text: ' dazu.' }],
+      },
+    ],
+    library: [],
+  }
+}
+
+/** Renders one link and hands back the sentence it sits in plus what followed it. */
+function renderOneLink(target: LinkTarget = { docId: DOC_ID }) {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const followed: LinkTarget[] = []
+  const { links } = renderDocumentJson(withLink(target), host, {
+    imageUrl: (id) => `/api/image/${id}`,
+    linkHref: (t) => `/ziel/${linkTargetId(t)}`,
+    followLink: (t) => followed.push(t),
+  })
+  const link = links[0]
+  if (!link) throw new Error('no link rendered')
+  return { host, link, followed, sentence: () => host.querySelector('p')?.textContent ?? '' }
+}
+
+function click(el: Element, init: MouseEventInit = {}): MouseEvent {
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true, ...init })
+  el.dispatchEvent(event)
+  return event
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+  vi.unstubAllGlobals()
+})
+
+describe('applyLinkTargetDescriptor — a reachable target', () => {
+  it('leaves the chip exactly as the renderer built it', () => {
+    const { link, followed } = renderOneLink()
+    applyLinkTargetDescriptor(link, { state: 'ok' }, () => {})
+    expect(link.anchor.isConnected).toBe(true)
+    expect(link.anchor.getAttribute('href')).toBe(`/ziel/${DOC_ID}`)
+    // Still the renderer's own anchor, so it still follows through the router
+    // instead of unmounting the page the student is typing into.
+    click(link.anchor)
+    expect(followed).toEqual([{ docId: DOC_ID }])
+  })
+})
+
+describe('applyLinkTargetDescriptor — a target that is gone', () => {
+  for (const state of ['archived', 'missing'] as const) {
+    it(`degrades a ${state} target to plain text the sentence still reads`, () => {
+      const { link, sentence } = renderOneLink()
+      applyLinkTargetDescriptor(link, { state }, () => {})
+      expect(sentence()).toBe('Siehe Kapitel 3 (nicht mehr verfügbar) dazu.')
+    })
+
+    it(`leaves a ${state} target with nothing to click and nothing to focus`, () => {
+      const { host, link, followed } = renderOneLink()
+      applyLinkTargetDescriptor(link, { state }, () => {})
+      expect(host.querySelector('a')).toBeNull()
+      expect(host.querySelector('[href]')).toBeNull()
+      expect(followed).toEqual([])
+    })
+  }
+
+  it('says the same thing whether the target is archived or deleted', () => {
+    // Which of the two it is is the operator's business. To the student both
+    // are „gone", and telling them apart would say something about a target
+    // they cannot reach.
+    const archived = renderOneLink()
+    applyLinkTargetDescriptor(archived.link, { state: 'archived' }, () => {})
+    const missing = renderOneLink()
+    applyLinkTargetDescriptor(missing.link, { state: 'missing' }, () => {})
+    expect(archived.sentence()).toBe(missing.sentence())
+  })
+
+  it('drops the target it used to point at along with the link', () => {
+    const { host, link } = renderOneLink({ docId: DOC_ID, anchorId: 'anc_1' })
+    applyLinkTargetDescriptor(link, { state: 'missing' }, () => {})
+    expect(host.innerHTML).not.toContain(DOC_ID)
+    expect(host.innerHTML).not.toContain('anc_1')
+  })
+})
+
+describe('applyLinkTargetDescriptor — a locked target', () => {
+  it('stays clickable and opens the unlock card instead of the target', () => {
+    const opened: LinkTargetDescriptor[] = []
+    const { host, link, followed } = renderOneLink()
+    applyLinkTargetDescriptor(link, LOCKED, (d) => opened.push(d))
+
+    const chip = host.querySelector('a')
+    if (!chip) throw new Error('a locked chip must stay a link')
+    const event = click(chip)
+
+    expect(opened).toEqual([LOCKED])
+    expect(event.defaultPrevented).toBe(true)
+    // The renderer's own follow must NOT also fire: it would push the document
+    // URL and land the student on the refusal this ticket exists to replace.
+    expect(followed).toEqual([])
+  })
+
+  it('re-points at the Einheit, so every path out of it sells rather than 404s', () => {
+    // A middle click, „open in new tab", or a browser with our JS not running
+    // all fall through to the href. Pointed at the document it would land on
+    // the same dead end; pointed at the Einheit it lands on the paywall.
+    const { host, link } = renderOneLink()
+    applyLinkTargetDescriptor(link, LOCKED, () => {})
+    expect(host.querySelector('a')?.getAttribute('href')).toBe(`/einheiten/${UNIT_ID}`)
+  })
+
+  it('leaves a modified click to the browser, exactly as a live chip does', () => {
+    const opened: LinkTargetDescriptor[] = []
+    const { host, link } = renderOneLink()
+    applyLinkTargetDescriptor(link, LOCKED, (d) => opened.push(d))
+    const chip = host.querySelector('a')!
+    for (const init of [{ ctrlKey: true }, { metaKey: true }, { shiftKey: true }, { button: 1 }]) {
+      expect(click(chip, init).defaultPrevented).toBe(false)
+    }
+    expect(opened).toEqual([])
+  })
+
+  it('keeps the label and says it is locked to a reader who gets no glyph', () => {
+    const { host, link } = renderOneLink()
+    applyLinkTargetDescriptor(link, LOCKED, () => {})
+    const chip = host.querySelector('a')!
+    expect(chip.textContent).toBe('Kapitel 3')
+    expect(chip.getAttribute('aria-label')).toContain('Einheit 3')
+    expect(chip.getAttribute('aria-label')).toContain('gesperrt')
+  })
+
+  it('reveals nothing about the target beyond the words already in the sentence', () => {
+    // The Einheit is the offer and may be named. The locked DOCUMENT's title is
+    // not the offer, and putting it in the page would tell an unentitled reader
+    // what is behind the paywall.
+    const { host, link } = renderOneLink()
+    applyLinkTargetDescriptor(link, LOCKED, () => {})
+    expect(host.textContent).not.toContain(LOCKED.title)
+  })
+})
+
+describe('resolveRenderedLinks — asking the resolver', () => {
+  function stubResolver(reply: (url: string) => unknown, ok = true) {
+    const calls: string[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        calls.push(url)
+        return { ok, json: async () => reply(url) } as Response
+      })
+    )
+    return calls
+  }
+
+  it('asks the resolver for the target kind and id the chip carries', async () => {
+    const calls = stubResolver(() => ({ state: 'ok' }))
+    const { link } = renderOneLink({ kursId: KURS_ID })
+    await resolveRenderedLinks([link], { onLocked: () => {} })
+    expect(calls).toEqual([`/api/link-target/kurs/${KURS_ID}`])
+  })
+
+  it('asks once per distinct target, however many chips point at it', async () => {
+    // Two chips into the same Dokument at different Sprungmarken are the same
+    // question: whether a target is reachable does not depend on the spot
+    // inside it.
+    const calls = stubResolver(() => ({ state: 'ok' }))
+    const a = renderOneLink({ docId: DOC_ID, anchorId: 'anc_1' })
+    const b = renderOneLink({ docId: DOC_ID, anchorId: 'anc_2' })
+    await resolveRenderedLinks([a.link, b.link], { onLocked: () => {} })
+    expect(calls).toEqual([`/api/link-target/document/${DOC_ID}`])
+  })
+
+  it('applies one verdict to every chip that shares the target', async () => {
+    stubResolver(() => ({ state: 'missing' }))
+    const a = renderOneLink({ docId: DOC_ID })
+    const b = renderOneLink({ docId: DOC_ID, anchorId: 'anc_2' })
+    await resolveRenderedLinks([a.link, b.link], { onLocked: () => {} })
+    expect(a.sentence()).toContain('nicht mehr verfügbar')
+    expect(b.sentence()).toContain('nicht mehr verfügbar')
+  })
+
+  it('leaves every chip alone when the resolver cannot be reached', async () => {
+    // FAIL OPEN, and deliberately so: a resolver outage must not silently
+    // unlink a whole document. An unresolved chip behaves exactly as it did
+    // before this ticket — clickable, and refused at the far end if it must be.
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('offline') }))
+    const { host, link, followed } = renderOneLink()
+    await resolveRenderedLinks([link], { onLocked: () => {} })
+    expect(host.querySelector('a')?.getAttribute('href')).toBe(`/ziel/${DOC_ID}`)
+    click(host.querySelector('a')!)
+    expect(followed).toEqual([{ docId: DOC_ID }])
+  })
+
+  it('leaves every chip alone when the answer is not a verdict', async () => {
+    // What an unauthenticated fetch actually gets: the proxy's redirect to the
+    // login page, i.e. HTML. Reading that as a verdict is the failure mode the
+    // parse exists to stop.
+    stubResolver(() => '<!DOCTYPE html><html lang="de">')
+    const { host, link } = renderOneLink()
+    await resolveRenderedLinks([link], { onLocked: () => {} })
+    expect(host.querySelector('a')?.getAttribute('href')).toBe(`/ziel/${DOC_ID}`)
+  })
+
+  it('leaves every chip alone on an error status', async () => {
+    stubResolver(() => ({ error: 'Nicht angemeldet.' }), false)
+    const { host, link } = renderOneLink()
+    await resolveRenderedLinks([link], { onLocked: () => {} })
+    expect(host.querySelector('a')?.getAttribute('href')).toBe(`/ziel/${DOC_ID}`)
+  })
+
+  it('touches nothing once the caller has gone away', async () => {
+    // The document is unmounted while the answers are in flight. Rewriting DOM
+    // that a later render already replaced would resurrect a chip nobody is
+    // looking at.
+    stubResolver(() => ({ state: 'missing' }))
+    const { host, link } = renderOneLink()
+    const controller = new AbortController()
+    controller.abort()
+    await resolveRenderedLinks([link], { onLocked: () => {}, signal: controller.signal })
+    expect(host.querySelector('a')?.getAttribute('href')).toBe(`/ziel/${DOC_ID}`)
+  })
+
+  it('does nothing at all for a document without links', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    await resolveRenderedLinks([], { onLocked: () => {} })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/unreachable-links.ts
+++ b/src/lib/unreachable-links.ts
@@ -1,0 +1,202 @@
+/**
+ * unreachable-links — what a link chip becomes when its target turns out to be
+ * locked, archived or deleted (#74, spec #63 user stories 21–23).
+ *
+ * The renderer builds every chip as a live `<a href>` because it cannot know
+ * any better: whether a target is REACHABLE is a server question, and asking it
+ * would put a fetch inside a pure DOM module. So the chips are reported back
+ * (`DocumentRenderResult.links`), resolved here, and the ones that turn out to
+ * be unreachable are rewritten in place.
+ *
+ * Three outcomes, and each is a different KIND of thing in the sentence:
+ *
+ * - **ok** — untouched. Still the renderer's own anchor, still following
+ *   through the router with the student's typed values intact.
+ * - **archived / missing** — no longer a link at all. It degrades to the words
+ *   the author wrote plus a quiet note, so the sentence still reads. Both say
+ *   the same thing: which of the two it is belongs to the operator, and telling
+ *   them apart would say something about a target the student cannot reach.
+ * - **locked** — still a link, and now a better one. It re-points at the
+ *   Einheit and opens the unlock card in place, so a reference becomes a way to
+ *   get the content rather than a dead end.
+ *
+ * FAIL OPEN. A resolver that cannot be reached, an answer that does not parse,
+ * an error status — all leave every chip exactly as the renderer built it. A
+ * document must never silently unlink itself because a request failed; an
+ * unresolved chip is no worse than it was before this ticket, and a wrongly
+ * blanked one is a document the student cannot navigate.
+ *
+ * Imperative on purpose, like everything below the renderer's container: React
+ * must not reconcile in there, so this reaches into the DOM directly and the
+ * one thing it hands BACK to React is the locked descriptor, which the card is
+ * rendered from as a sibling of the container.
+ */
+
+import { linkTargetUrl, unitUrl } from '@/lib/constants'
+import type { RenderedDocumentLink } from '@/lib/editor/document-render'
+import { isPlainLeftClick, linkTargetId, linkTargetKind, type LinkTarget } from '@/lib/editor/links'
+import {
+  LinkTargetDescriptorSchema,
+  type LinkTargetDescriptor,
+  type LockedLinkTarget,
+} from '@/lib/link-target-state'
+
+/** The class a degraded link wears — plain text, styled as an absence. */
+export const LINK_GONE_CLASS = 'doc-link-gone'
+
+/** …and the note beside it. Real text, not CSS: a reader has to hear it too. */
+export const LINK_GONE_NOTE_CLASS = 'doc-link-gone-note'
+
+/** What a link that no longer goes anywhere says. Deliberately quiet. */
+export const LINK_GONE_NOTE = ' (nicht mehr verfügbar)'
+
+/** The glyph a locked chip wears in place of its kind icon. */
+const LOCKED_ICON = '🔒'
+
+export interface ResolveLinksOptions {
+  /** Called when the student clicks a locked chip — React opens the card. */
+  onLocked(descriptor: LockedLinkTarget): void
+  /**
+   * Cancels the DOM writes, not the requests. The answers are tiny and
+   * in-flight ones are simply discarded: aborting them would buy nothing and
+   * cost a rejected promise to swallow on every unmount.
+   */
+  signal?: AbortSignal
+}
+
+/**
+ * Resolves every rendered link and applies the verdict to its chip.
+ *
+ * One request per DISTINCT target, not per chip: a document with a table of
+ * contents points at the same places repeatedly, and whether a target is
+ * reachable does not depend on which Sprungmarke inside it a chip aims at.
+ *
+ * Resolution is deliberately EAGER rather than on click. „Degrades to plain
+ * readable text" is a promise about what the student sees before they commit to
+ * anything — a chip that still looks like a link until it is clicked has not
+ * degraded, it has lied.
+ */
+export async function resolveRenderedLinks(
+  links: RenderedDocumentLink[],
+  options: ResolveLinksOptions
+): Promise<void> {
+  const byTarget = new Map<string, RenderedDocumentLink[]>()
+  for (const link of links) {
+    const key = targetKey(link.target)
+    const group = byTarget.get(key)
+    if (group) group.push(link)
+    else byTarget.set(key, [link])
+  }
+
+  await Promise.all(
+    Array.from(byTarget.values(), async (group) => {
+      const first = group[0]
+      if (!first) return
+      const descriptor = await fetchLinkTarget(first.target)
+      // No verdict, or the caller is gone: leave the chips as they are.
+      if (!descriptor || options.signal?.aborted) return
+      for (const link of group) applyLinkTargetDescriptor(link, descriptor, options.onLocked)
+    })
+  )
+}
+
+/** Identity of the thing a chip points at — the Sprungmarke is not part of it. */
+function targetKey(target: LinkTarget): string {
+  return `${linkTargetKind(target)}:${linkTargetId(target)}`
+}
+
+/**
+ * One resolver round-trip, or `null` for every way it can fail to produce a
+ * verdict — unreachable, non-OK status, unparseable body.
+ *
+ * The parse is not ceremony. An unauthenticated request is answered by the
+ * proxy with a redirect to the login page, so what arrives is HTML with a 200
+ * on it; without the schema that would be read as a verdict.
+ */
+async function fetchLinkTarget(target: LinkTarget): Promise<LinkTargetDescriptor | null> {
+  try {
+    const response = await fetch(linkTargetUrl(linkTargetKind(target), linkTargetId(target)), {
+      headers: { Accept: 'application/json' },
+    })
+    if (!response.ok) return null
+    const parsed = LinkTargetDescriptorSchema.safeParse(await response.json())
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Rewrites one chip for what its target turned out to be.
+ *
+ * Both rewrites REPLACE the element rather than mutating it, and that is the
+ * load-bearing part: the renderer bound a click listener that pushes the
+ * target's URL through the router, there is no handle to remove it with, and a
+ * locked chip that still ran it would navigate to the very refusal this ticket
+ * exists to replace. A fresh element carries no listeners.
+ */
+export function applyLinkTargetDescriptor(
+  link: RenderedDocumentLink,
+  descriptor: LinkTargetDescriptor,
+  onLocked: (descriptor: LockedLinkTarget) => void
+): void {
+  if (descriptor.state === 'ok') return
+  if (descriptor.state === 'locked') {
+    link.anchor.replaceWith(lockedChip(link, descriptor, onLocked))
+    return
+  }
+  link.anchor.replaceWith(goneText(link))
+}
+
+/**
+ * The author's words, a quiet note, and no link — built fresh rather than
+ * stripped down, so no `data-link-*` attribute survives to say where the
+ * sentence used to point.
+ */
+function goneText(link: RenderedDocumentLink): HTMLElement {
+  const doc = link.anchor.ownerDocument
+  const span = doc.createElement('span')
+  span.className = LINK_GONE_CLASS
+  span.textContent = link.label
+  const note = doc.createElement('span')
+  note.className = LINK_GONE_NOTE_CLASS
+  // Real text rather than a CSS `::after`, unlike the kind glyph: the glyph is
+  // decoration a sighted reader can infer, while „this no longer exists" is the
+  // whole message and has to reach a screen reader too.
+  note.textContent = LINK_GONE_NOTE
+  span.append(note)
+  return span
+}
+
+/**
+ * A locked chip: same words, a lock instead of the kind glyph, and an href that
+ * now points at the EINHEIT rather than at the target.
+ *
+ * Re-pointing the href is what makes every path out of this chip land
+ * somewhere that sells. A plain click is intercepted and opens the card without
+ * leaving the page — but a middle click, „open in new tab", or our JS simply
+ * not running all fall through to the href, and the Einheit page is the paywall
+ * with its teaser and „Freischalten" button. Left pointing at the document,
+ * every one of those would land on a refusal.
+ */
+function lockedChip(
+  link: RenderedDocumentLink,
+  descriptor: LockedLinkTarget,
+  onLocked: (descriptor: LockedLinkTarget) => void
+): HTMLAnchorElement {
+  const chip = link.anchor.cloneNode(true) as HTMLAnchorElement
+  chip.setAttribute('href', unitUrl(descriptor.unit.id))
+  chip.dataset['linkIcon'] = LOCKED_ICON
+  // What the stylesheet mutes the chip by. Kept as state rather than a class so
+  // the chip stays a `.doc-link` and keeps its shape in the sentence.
+  chip.dataset['linkState'] = 'locked'
+  // The glyph is CSS chrome, so this is how „locked, and it is in that Einheit"
+  // reaches a reader who gets no icon.
+  chip.setAttribute('aria-label', `${link.label} – gesperrt: Einheit ${descriptor.unit.title}`)
+  chip.addEventListener('click', (event) => {
+    if (!isPlainLeftClick(event)) return
+    event.preventDefault()
+    onLocked(descriptor)
+  })
+  return chip
+}


### PR DESCRIPTION
## Summary

- **`GET /api/link-target/[kind]/[id]`** — a link's target can be unbought, archived or deleted, and RLS makes those indistinguishable: `documents` SELECT is entitlement-gated, so an unentitled student's lookup returns no row at all, and naming the Einheit to buy needs exactly the row the policy withholds. The route reads past RLS with the service-role client and answers with a **minimal descriptor, never content** — a thin shell over the pure decision, with the same auth requirement and admin bypass as the file proxies.
- **`lib/link-target-state.ts`** — one pure function decides both the verdict (`ok` / `locked` / `archived` / `missing`) and what may cross with it, so a field cannot be attached to a verdict that must not carry it. **`archived` beats `locked`**, pinned by a test: nobody is offered €3 for an Einheit that stays dark.
- **`lib/unreachable-links.ts`** — the renderer now reports the chips it built (`DocumentRenderResult.links`, the same contract `renderTargets` has). They resolve eagerly, one request per *distinct* target. Archived/deleted degrade to the author's words plus a quiet „(nicht mehr verfügbar)" so the sentence still reads; locked stays a chip, re-pointed at its Einheit so a middle click or JS-off lands on the paywall rather than a dead end.
- **`LinkLockedCard`** opens in place rather than navigating, so nothing the student typed is unmounted. It renders `UnitPaywall` itself — the same component the locked Einheit page shows — so the Einheit's teaser reaches this surface by construction rather than by a second copy.
- **Two rules that are easy to break**, both documented and tested: each rewrite **replaces** the element (the renderer bound a click listener with no handle to remove, and a mutated locked chip would still navigate to the refusal this replaces), and the whole path **fails open** — an unreachable resolver, a bad status, or a body that is not a verdict leaves every chip exactly as it was.
- **AC „verify the teaser" was a no-op, as the ticket suspected** — `UnitCard` already clamps it in the grid, `UnitPaywall` already renders it on the locked Einheit page. Verified, not rebuilt.
- **No migration.** No schema change, so there is nothing to apply to prod.

## Test plan

- `npm run lint`, `npm test` (580 passing, 36 new), `npm run build` — all green on HEAD.
- 16 unit tests on the decision, written as the questions a reviewer asks of a paywall: who is told what, which rule wins, and what may cross the wire.
- 20 jsdom tests on the chip rewrite, driven through the **real renderer** — half of what this has to get right is undoing what the renderer did.
- The three PostgREST embeds were probed against the dev project; a broken embed would silently read as `missing`.
- Two-axis review run; it caught a real bug (a failed read was reported as `missing`, silently unlinking a live link) — fixed in the second commit.
- **Still needs manual QA**: the repo has no component or E2E seam, so nothing here has been driven through a browser with a real session.

## Two judgement calls worth a look

- A `{unitId}` link never locks — it navigates to the Einheit page, which *is* the paywall with teaser and unlock button. A card would be a worse copy of the page one click away.
- A locked chip's `href` is re-pointed at the Einheit — beyond the AC's letter. It means middle-click and JS-off land on the paywall instead of a dead end, but a middle-click on a chip labelled „Kapitel 3" does go somewhere the author did not link.

## Adjacent, untouched

`userHasUnitAccess()` also swallows its error and returns `false`, so a transient failure would show an unlock card to a student who owns the Einheit. Pre-existing and shared with the Unit page, so left alone.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)